### PR TITLE
[122] QCamera2: Fix warnings, add null checks, fix unused variables

### DIFF
--- a/QCamera2/HAL3/QCamera3HWI.cpp
+++ b/QCamera2/HAL3/QCamera3HWI.cpp
@@ -263,15 +263,15 @@ const QCamera3HardwareInterface::QCameraMap<
 };
 
 camera3_device_ops_t QCamera3HardwareInterface::mCameraOps = {
-    initialize:                         QCamera3HardwareInterface::initialize,
-    configure_streams:                  QCamera3HardwareInterface::configure_streams,
-    register_stream_buffers:            NULL,
-    construct_default_request_settings: QCamera3HardwareInterface::construct_default_request_settings,
-    process_capture_request:            QCamera3HardwareInterface::process_capture_request,
-    get_metadata_vendor_tag_ops:        NULL,
-    dump:                               QCamera3HardwareInterface::dump,
-    flush:                              QCamera3HardwareInterface::flush,
-    reserved:                           {0},
+    .initialize =                         QCamera3HardwareInterface::initialize,
+    .configure_streams =                  QCamera3HardwareInterface::configure_streams,
+    .register_stream_buffers =            NULL,
+    .construct_default_request_settings = QCamera3HardwareInterface::construct_default_request_settings,
+    .process_capture_request =            QCamera3HardwareInterface::process_capture_request,
+    .get_metadata_vendor_tag_ops =        NULL,
+    .dump =                               QCamera3HardwareInterface::dump,
+    .flush =                              QCamera3HardwareInterface::flush,
+    .reserved =                           {0},
 };
 
 /*===========================================================================
@@ -992,7 +992,6 @@ int QCamera3HardwareInterface::configureStreams(
     uint8_t eis_prop_set;
     uint32_t maxEisWidth = 0;
     uint32_t maxEisHeight = 0;
-    int32_t hal_version = CAM_HAL_V3;
 
     size_t count = IS_TYPE_MAX;
     count = MIN(gCamCapability[mCameraId]->supported_is_types_cnt, count);
@@ -1580,7 +1579,7 @@ int QCamera3HardwareInterface::validateCaptureRequest(
         return BAD_VALUE;
     }
     if (request->num_output_buffers >= MAX_NUM_STREAMS) {
-        ALOGE("%s: Number of buffers %d equals or is greater than maximum number of streams!",
+        ALOGE("%s: Number of buffers %d equals or is greater than (%d) maximum number of streams!",
                 __func__, request->num_output_buffers, MAX_NUM_STREAMS);
         return BAD_VALUE;
     }
@@ -4153,8 +4152,6 @@ void QCamera3HardwareInterface::dumpMetadataToFile(tuning_params_t &meta,
                                                    const char *type,
                                                    uint32_t frameNumber)
 {
-    uint32_t frm_num = 0;
-
     //Some sanity checks
     if (meta.tuning_sensor_data_size > TUNING_SENSOR_DATA_MAX) {
         ALOGE("%s : Tuning sensor data size bigger than expected %d: %d",
@@ -7706,6 +7703,9 @@ QCamera3ReprocessChannel *QCamera3HardwareInterface::addOfflineReprocChannel(
         delete pChannel;
         return NULL;
     }
+
+    if (metadata == NULL)
+        ALOGV("%s: not fatal - metadata is NULL!!\n", __func__);
 
     // pp feature config
     cam_pp_feature_config_t pp_config;

--- a/QCamera2/HAL3/QCamera3Mem.cpp
+++ b/QCamera2/HAL3/QCamera3Mem.cpp
@@ -665,6 +665,9 @@ int QCamera3GrallocMemory::registerBuffer(buffer_handle_t *buffer,
         return ALREADY_EXISTS;
     }
 
+    if (type < 0)
+        ALOGV("%s: type appears to be invalid!\n", __func__);
+
     Mutex::Autolock lock(mLock);
     if (mBufferCount >= (MM_CAMERA_MAX_NUM_FRAMES - 1)) {
         ALOGE("%s: Number of buffers %d greater than what's supported %d",

--- a/QCamera2/QCamera2Factory.cpp
+++ b/QCamera2/QCamera2Factory.cpp
@@ -355,7 +355,7 @@ int QCamera2Factory::camera_device_open(
 }
 
 struct hw_module_methods_t QCamera2Factory::mModuleMethods = {
-    open: QCamera2Factory::camera_device_open,
+    .open = QCamera2Factory::camera_device_open,
 };
 
 /*===========================================================================

--- a/QCamera2/QCamera2Hal.cpp
+++ b/QCamera2/QCamera2Hal.cpp
@@ -31,25 +31,25 @@
 #include "HAL3/QCamera3VendorTags.h"
 
 static hw_module_t camera_common = {
-    tag: HARDWARE_MODULE_TAG,
-    module_api_version: CAMERA_MODULE_API_VERSION_2_3,
-    hal_api_version: HARDWARE_HAL_API_VERSION,
-    id: CAMERA_HARDWARE_MODULE_ID,
-    name: "QCamera Module",
-    author: "Qualcomm Innovation Center Inc",
-    methods: &qcamera::QCamera2Factory::mModuleMethods,
-    dso: NULL,
-    reserved: {0}
+    .tag = HARDWARE_MODULE_TAG,
+    .module_api_version = CAMERA_MODULE_API_VERSION_2_3,
+    .hal_api_version = HARDWARE_HAL_API_VERSION,
+    .id = CAMERA_HARDWARE_MODULE_ID,
+    .name = "QCamera Module",
+    .author = "Qualcomm Innovation Center Inc",
+    .methods = &qcamera::QCamera2Factory::mModuleMethods,
+    .dso = NULL,
+    .reserved = {0}
 };
 
 camera_module_t HAL_MODULE_INFO_SYM = {
-    common: camera_common,
-    get_number_of_cameras: qcamera::QCamera2Factory::get_number_of_cameras,
-    get_camera_info: qcamera::QCamera2Factory::get_camera_info,
-    set_callbacks: qcamera::QCamera2Factory::set_callbacks,
-    get_vendor_tag_ops: qcamera::QCamera3VendorTags::get_vendor_tag_ops,
-    open_legacy: qcamera::QCamera2Factory::open_legacy,
-    set_torch_mode: NULL,
-    init : NULL,
-    reserved: {0}
+    .common = camera_common,
+    .get_number_of_cameras = qcamera::QCamera2Factory::get_number_of_cameras,
+    .get_camera_info = qcamera::QCamera2Factory::get_camera_info,
+    .set_callbacks = qcamera::QCamera2Factory::set_callbacks,
+    .get_vendor_tag_ops = qcamera::QCamera3VendorTags::get_vendor_tag_ops,
+    .open_legacy = qcamera::QCamera2Factory::open_legacy,
+    .set_torch_mode = NULL,
+    .init  = NULL,
+    .reserved = {0}
 };


### PR DESCRIPTION
One unused variable happens to be there because of an ifdef
for 8974 (as it's used on other chips-HALs).
Others are happening for all.

Fix warnings by deleting unused variables where applicable
and, where not, add null checks to use the vars.

Fixes building with -Werror.
