### PR TITLE
Set 100% jpeg quality as default

### DIFF
--- a/QCamera2/HAL/QCameraParameters.cpp
+++ b/QCamera2/HAL/QCameraParameters.cpp
@@ -4695,8 +4695,8 @@ int32_t QCameraParameters::initDefaultParameters()
        m_pCapability->raw_dim[0].width, m_pCapability->raw_dim[0].height);
 
     //set default jpeg quality and thumbnail quality
-    set(KEY_JPEG_QUALITY, 85);
-    set(KEY_JPEG_THUMBNAIL_QUALITY, 85);
+    set(KEY_JPEG_QUALITY, 100);
+    set(KEY_JPEG_THUMBNAIL_QUALITY, 100);
 
     // Set FPS ranges
     if (m_pCapability->fps_ranges_tbl_cnt > 0 &&
@@ -8959,7 +8959,7 @@ uint32_t QCameraParameters::getJpegQuality()
 {
     int quality = getInt(KEY_JPEG_QUALITY);
     if (quality < 0) {
-        quality = 85; // set to default quality value
+        quality = 100; // set to default quality value
     }
     return (uint32_t)quality;
 }


### PR DESCRIPTION
Set 100% jpeg quality as default for pics and thumbnails.
