### PR TITLE
QCamera2: HAL: revert default video format to PIXEL_FORMAT_YUV420SP

### DIFF
--- a/QCamera2/HAL/QCameraParameters.cpp
+++ b/QCamera2/HAL/QCameraParameters.cpp
@@ -5038,9 +5038,8 @@ int32_t QCameraParameters::initDefaultParameters()
     // Set default preview format
     CameraParameters::setPreviewFormat(PIXEL_FORMAT_YUV420SP);
 
-    // Set default Video Format as OPAQUE
-    //Internally both Video and Camera subsystems use NV21_VENUS
-    set(KEY_VIDEO_FRAME_FORMAT, PIXEL_FORMAT_ANDROID_OPAQUE);
+    // Set default Video Format
+    set(KEY_VIDEO_FRAME_FORMAT, PIXEL_FORMAT_YUV420SP);
 
     // Set supported picture formats
     String8 pictureTypeValues(PIXEL_FORMAT_JPEG);


### PR DESCRIPTION
AOSP M expects this format according to
https://android.googlesource.com/platform/hardware/qcom/camera/+/android-6.0.1_r58/QCamera2/HAL/QCameraParameters.cpp#4738
PIXEL_FORMAT_ANDROID_OPAQUE causes errors in VENC because VENC doesn't
support opaque formats from HAL1. This is only newly added in Android N.
