### PR TITLE
Resolve path related build breaks on cm-13.0

### DIFF
--- a/QCamera2/Android.mk
+++ b/QCamera2/Android.mk
@@ -52,11 +52,13 @@ LOCAL_C_INCLUDES := \
         frameworks/native/include/media/hardware \
         frameworks/native/include/media/openmax \
         hardware/qcom/media/libstagefrighthw \
+        hardware/qcom/media/default/libstagefrighthw \
         system/media/camera/include \
         $(LOCAL_PATH)/../mm-image-codec/qexif \
         $(LOCAL_PATH)/../mm-image-codec/qomx_core \
         $(LOCAL_PATH)/util \
         hardware/qcom/media/mm-core/inc \
+        hardware/qcom/media/default/mm-core/inc \
 
 #HAL 1.0 Include paths
 LOCAL_C_INCLUDES += \

--- a/QCamera2/HAL/QCamera2HWI.h
+++ b/QCamera2/HAL/QCamera2HWI.h
@@ -35,8 +35,8 @@
 #include <utils/Log.h>
 #include <utils/Mutex.h>
 #include <utils/Condition.h>
-#include <QCameraParameters.h>
 
+#include "QCameraParameters.h"
 #include "QCameraTrace.h"
 #include "QCameraQueue.h"
 #include "QCameraCmdThread.h"

--- a/QCamera2/QCamera2Factory.cpp
+++ b/QCamera2/QCamera2Factory.cpp
@@ -39,7 +39,7 @@
 #include "HAL/QCamera2HWI.h"
 #include "HAL3/QCamera3HWI.h"
 #include "QCamera2Factory.h"
-#include "QCameraMuxer.h"
+#include "HAL/QCameraMuxer.h"
 
 using namespace android;
 


### PR DESCRIPTION
CyanogenMods source environment is slightly different from AOSP resulting in a couple of build breaks

As far as i am concerned the commits should not affect the building process in any way even for AOSP users.

Issues were mainly related to paths, such as missing header errors due to a difference in the compiler, taking a header from the original qcom camera hal causing invalid class member definitions and finally differences in the hardware/qcom/media path

Please take a look at the commits, thanks for your understanding.
