### PR TITLE
sony: camera: Restrict the project to Sony AOSP devices only

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,3 +1,5 @@
+ifneq ($(filter yukon rhine shinano kanuti kitakami loire,$(PRODUCT_PLATFORM)),)
+
 MM_V4L2_DRIVER_LIST += msm8960
 MM_V4L2_DRIVER_LIST += msm8974
 MM_V4L2_DRIVER_LIST += msm8916
@@ -19,4 +21,6 @@ ifneq (,$(filter $(MM_V4L2_DRIVER_LIST),$(TARGET_BOARD_PLATFORM)))
       include $(call all-subdir-makefiles)
     endif
   endif
+endif
+
 endif


### PR DESCRIPTION
- Avoid including init_sony into a different device
  built inside the same build tree as Sony AOSP

Change-Id: I63c24ec3b5e171017b44d8d3388a1a5ea08e4da5
