### PR TITLE
QCamera2: HAL: Changes to enable FD in Video using setprop

### DIFF
--- a/QCamera2/HAL/QCamera2HWI.cpp
+++ b/QCamera2/HAL/QCamera2HWI.cpp
@@ -6417,7 +6417,8 @@ int32_t QCamera2HardwareInterface::addPreviewChannel()
     }
 
     if (((mParameters.getDcrf() == true)
-            || (mParameters.getRecordingHintValue() != true))
+            || (mParameters.getRecordingHintValue() != true)
+            || (mParameters.isFDInVideoEnabled()))
             && (!mParameters.isSecureMode())) {
 
         rc = addStreamToChannel(pChannel, CAM_STREAM_TYPE_ANALYSIS,
@@ -7583,7 +7584,8 @@ int32_t QCamera2HardwareInterface::preparePreview()
             if (isLongshotEnabled()) {
                 sendCommand(CAMERA_CMD_LONGSHOT_OFF, arg, arg);
             }
-            if (mParameters.isFaceDetectionEnabled()) {
+            if (mParameters.isFaceDetectionEnabled()
+                    && (!mParameters.isFDInVideoEnabled())) {
                 sendCommand(CAMERA_CMD_STOP_FACE_DETECTION, arg, arg);
             }
             if (mParameters.isHistogramEnabled()) {

--- a/QCamera2/HAL/QCameraParameters.cpp
+++ b/QCamera2/HAL/QCameraParameters.cpp
@@ -4038,7 +4038,11 @@ int32_t QCameraParameters::setRecordingHint(const QCameraParameters& params)
                 updateParamEntry(KEY_RECORDING_HINT, str);
                 setRecordingHintValue(value);
                 if (getFaceDetectionOption() == true) {
-                    setFaceDetection(value > 0 ? false : true, false);
+                    if (!isFDInVideoEnabled()) {
+                        setFaceDetection(value > 0 ? false : true, false);
+                    } else {
+                        setFaceDetection(true, false);
+                    }
                 }
                 if (m_bDISEnabled) {
                     CDBG_HIGH("%s: %d: Setting DIS value again", __func__, __LINE__);
@@ -12234,7 +12238,8 @@ bool QCameraParameters::setStreamConfigure(bool isCapture,
         // Analysis stream is needed in all use cases of DCRF and needed only in camera mode in
         // in non DCRF use cases
         if ((getDcrf() == true) ||
-                (getRecordingHintValue() != true)) {
+                (getRecordingHintValue() != true) ||
+                (isFDInVideoEnabled())) {
             stream_config_info.type[stream_config_info.num_streams] =
                     CAM_STREAM_TYPE_ANALYSIS;
             getStreamDimension(CAM_STREAM_TYPE_ANALYSIS,
@@ -13363,6 +13368,26 @@ int32_t QCameraParameters::setInstantAEC(uint8_t enable, bool initCommit)
     CDBG_HIGH(" setInstantAEC set value %d", enable);
     m_bInstantAEC = enable;
     return rc;
+}
+
+/*===========================================================================
+ * FUNCTION   : isFDInVideoEnabled
+ *
+ * DESCRIPTION: FD in Video change
+ *
+ * PARAMETERS : none
+ *
+ * RETURN     : TRUE  : If FD in Video enabled
+ *              FALSE : If FD in Video disabled
+ *==========================================================================*/
+bool QCameraParameters::isFDInVideoEnabled()
+{
+    char value[PROPERTY_VALUE_MAX];
+    bool fdvideo = FALSE;
+    property_get("persist.camera.fdvideo", value, "0");
+    fdvideo = (atoi(value) > 0) ? TRUE : FALSE;
+    CDBG("%s: FD in Video enabled : %d", __func__, fdvideo);
+    return fdvideo;
 }
 
 }; // namespace qcamera

--- a/QCamera2/HAL/QCameraParameters.h
+++ b/QCamera2/HAL/QCameraParameters.h
@@ -824,6 +824,7 @@ public:
             cam_related_system_calibration_data_t* calib);
     int32_t bundleRelatedCameras(bool sync, uint32_t sessionid);
     int32_t setInstantAEC(uint8_t enable, bool initCommit);
+    bool isFDInVideoEnabled();
 private:
     int32_t setPreviewSize(const QCameraParameters& );
     int32_t setVideoSize(const QCameraParameters& );


### PR DESCRIPTION
Added changes to enable Face detection in video
using setprop.
analysis stream will be added in video mode
for face detection.

Change-Id: Ic1e783a5d6ccfcb8bf5b50970bb3b6d10e8a1474
