### PR TITLE
QCamera2: Skip dual cam calibration when in single cam mode

### DIFF
--- a/QCamera2/HAL/QCamera2HWI.cpp
+++ b/QCamera2/HAL/QCamera2HWI.cpp
@@ -9105,20 +9105,25 @@ void *QCamera2HardwareInterface::deferredWorkRoutine(void *obj)
                         pme->mParameters.init(cap,
                                 pme->mCameraHandle,
                                 pme);
-                        rc = pme->mParameters.getRelatedCamCalibration(
-                            &(pme->mJpegMetadata.otp_calibration_data));
-                        CDBG("%s: Dumping Calibration Data Version Id %f rc %d",
-                                __func__,
-                                pme->mJpegMetadata.otp_calibration_data.calibration_format_version,
-                                rc);
-                        if (rc != 0) {
-                            ALOGE("getRelatedCamCalibration failed");
-                            pme->mCameraHandle->ops->close_camera(
-                                pme->mCameraHandle->camera_handle);
-                            pme->mCameraHandle = NULL;
-                            break;
+                        // Get related cam calibration only in
+                        // dual camera mode
+                        if (pme->getRelatedCamSyncInfo()->sync_control ==
+                                CAM_SYNC_RELATED_SENSORS_ON) {
+                            rc = pme->mParameters.getRelatedCamCalibration(
+                                &(pme->mJpegMetadata.otp_calibration_data));
+                            CDBG("%s: Dumping Calibration Data Version Id %f rc %d",
+                                    __func__,
+                                    pme->mJpegMetadata.otp_calibration_data.calibration_format_version,
+                                    rc);
+                            if (rc != 0) {
+                                ALOGE("getRelatedCamCalibration failed");
+                                pme->mCameraHandle->ops->close_camera(
+                                    pme->mCameraHandle->camera_handle);
+                                pme->mCameraHandle = NULL;
+                                break;
+                            }
+                            pme->m_bRelCamCalibValid = true;
                         }
-                        pme->m_bRelCamCalibValid = true;
                         pme->mJpegMetadata.sensor_mount_angle  =
                             cap->sensor_mount_angle;
                         pme->mJpegMetadata.default_sensor_flip = FLIP_NONE;


### PR DESCRIPTION
Previously, there was some unnecessary dual-camera related
calibration and logging which occurred even when running in
single cam mode. Now there is a check to skip these steps
in single cam mode.

Change-Id: I09da1f8400e0ca6ce24749fddb72f287d5dfa104
CRs-Fixed: 941802
