### PR TITLE
QCamera2: Set CDS to Off by default in HAL3.

### DIFF
--- a/QCamera2/HAL3/QCamera3HWI.cpp
+++ b/QCamera2/HAL3/QCamera3HWI.cpp
@@ -96,9 +96,9 @@ volatile uint32_t gCamHal3LogLevel = 0;
 extern uint8_t gNumCameraSessions;
 
 const QCamera3HardwareInterface::QCameraPropMap QCamera3HardwareInterface::CDS_MAP [] = {
-    {"On",  CAM_CDS_MODE_ON},
-    {"Off", CAM_CDS_MODE_OFF},
-    {"Auto",CAM_CDS_MODE_AUTO}
+    {"on",  CAM_CDS_MODE_ON},
+    {"off", CAM_CDS_MODE_OFF},
+    {"auto",CAM_CDS_MODE_AUTO}
 };
 
 const QCamera3HardwareInterface::QCameraMap<
@@ -6787,11 +6787,11 @@ camera_metadata_t* QCamera3HardwareInterface::translateCapabilityToMetadata(int 
     /* CDS default */
     char prop[PROPERTY_VALUE_MAX];
     memset(prop, 0, sizeof(prop));
-    property_get("persist.camera.CDS", prop, "Auto");
-    cam_cds_mode_type_t cds_mode = CAM_CDS_MODE_AUTO;
+    property_get("persist.camera.CDS", prop, "off");
+    cam_cds_mode_type_t cds_mode = CAM_CDS_MODE_OFF;
     cds_mode = lookupProp(CDS_MAP, METADATA_MAP_SIZE(CDS_MAP), prop);
     if (CAM_CDS_MODE_MAX == cds_mode) {
-        cds_mode = CAM_CDS_MODE_AUTO;
+        cds_mode = CAM_CDS_MODE_OFF;
     }
     //@note: force cds mode to be OFF when TNR is enabled.
     if (m_bTnrEnabled == true) {


### PR DESCRIPTION
Issue:
With CDS set to Auto, frame skip happens during CDS toggling.
But due to scheduling problems, the frame skip information is
not being updated properly in metadata, resulting in framework
indefinitely waiting for the skipped frame.

Fix:
Set default value of CDS in HAL3 to Off. It can still be enabled
via setprop - persist.camera.CDS, if needed.

Change-Id: I4df0a975930573a9bc774c980db4acd3fb4a7012
