### PR TITLE
QCamera2: Prevent attempt to map unallocated stream buffers

### DIFF
--- a/QCamera2/HAL/QCameraStream.cpp
+++ b/QCamera2/HAL/QCameraStream.cpp
@@ -1578,6 +1578,12 @@ int32_t QCameraStream::mapBuffers()
 {
     int32_t rc = NO_ERROR;
     QCameraBufferMaps bufferMaps;
+
+    if (mStreamBufs == NULL) {
+        ALOGE("%s: Stream buffers not allocated", __func__);
+        return UNKNOWN_ERROR;
+    }
+
     uint8_t numBufsToMap = mStreamBufs->getMappable();
     for (uint32_t i = 0; i < numBufsToMap; i++) {
         ssize_t bufSize = mStreamBufs->getSize(i);


### PR DESCRIPTION
Previously, after buffer allocation had failed, the deferred thread
would incorrectly continue trying to map the buffers. This lead to
a crash. Now mapping is not attempted after failed buffer
allocation.

Change-Id: I169700f01d79cdf71154906852c3aab60e0ac343
