### PR TITLE
QCamera2: Correct the condition to identify out of PP buffers

### DIFF
--- a/QCamera2/HAL/QCameraPostProc.cpp
+++ b/QCamera2/HAL/QCameraPostProc.cpp
@@ -779,7 +779,7 @@ bool QCameraPostProcessor::validatePostProcess(mm_camera_super_buf_t *frame)
         for (uint8_t i = 0; i < m_pReprocChannel->getNumOfStreams(); i++) {
             pStream = m_pReprocChannel->getStreamByIndex(i);
             if (pStream && (m_inputPPQ.getCurrentSize() > 0) &&
-                    m_ongoingPPQ.getCurrentSize() >=  pStream->getNumQueuedBuf()) {
+                    (pStream->getNumQueuedBuf() <= 0)) {
                 CDBG_HIGH("Out of PP Buffer PPQ = %d ongoingQ = %d Jpeg = %d onJpeg = %d",
                         m_inputPPQ.getCurrentSize(), m_inputPPQ.getCurrentSize(),
                         m_inputJpegQ.getCurrentSize(), m_ongoingJpegQ.getCurrentSize());


### PR DESCRIPTION
The logic in validatePostProcess for detecting a lack of PP
buffers was incorrect, and could signal this error condition
incorrectly in some cases. This check has been fixed to simply
check that we have at least one buffer queued to kernel.

CRs-Fixed: 951363
Change-Id: Id014fff3ea5d206e7f2235228e9e4eb1c84e116c
