### PR TITLE
QCamera2: Fix for flickering on GPU composition

### DIFF
--- a/QCamera2/HAL/QCameraMem.cpp
+++ b/QCamera2/HAL/QCameraMem.cpp
@@ -1871,6 +1871,8 @@ int32_t QCameraGrallocMemory::dequeueBuffer()
                 return BAD_INDEX;
             }
 
+            setMetaData(mPrivateHandle[dequeuedIdx], UPDATE_COLOR_SPACE,
+                    &mColorSpace);
             mCameraMemory[dequeuedIdx] =
                     mGetMemory(mPrivateHandle[dequeuedIdx]->fd,
                     (size_t)mPrivateHandle[dequeuedIdx]->size,


### PR DESCRIPTION
Setting the color space metadata for preview buffers which are
dequeued on the fly.

CRs-Fixed: 948963

Change-Id: Ia92ab08ecb4e38569c32ecac096b0b5ca30ea813
