### PR TITLE
QCamera2: Changes to update UPDATE_REFRESH_RATE to display.

### DIFF
--- a/QCamera2/HAL/QCameraMem.cpp
+++ b/QCamera2/HAL/QCameraMem.cpp
@@ -1856,6 +1856,8 @@ int32_t QCameraGrallocMemory::dequeueBuffer()
 
             mPrivateHandle[dequeuedIdx] =
                     (struct private_handle_t *)(*mBufferHandle[dequeuedIdx]);
+            //update max fps info
+            setMetaData(mPrivateHandle[dequeuedIdx], UPDATE_REFRESH_RATE, (void*)&mMaxFPS);
             mMemInfo[dequeuedIdx].main_ion_fd = open("/dev/ion", O_RDONLY);
             if (mMemInfo[dequeuedIdx].main_ion_fd < 0) {
                 ALOGE("%s: failed: could not open ion device", __func__);


### PR DESCRIPTION
UPDATE_REFRESH_RATE was not updated for all the frames. Display
was assuming 60fps as default frame rate in such cases.
Change is to update UPDATE_REFRESH_RATE for deferred preview buffers
as well.

Change-Id: I81a4d6f62ad57e3df004ae103bc5ebc32627827a
