### PR TITLE
QCamera2: Fix metadata stream buffer memory leak.

### DIFF
--- a/QCamera2/HAL/QCamera2HWI.cpp
+++ b/QCamera2/HAL/QCamera2HWI.cpp
@@ -1695,6 +1695,7 @@ QCamera2HardwareInterface::~QCamera2HardwareInterface()
     mDeferredWorkThread.exit();
 
     if (mMetadataMem != NULL) {
+        mMetadataMem->deallocate();
         delete mMetadataMem;
         mMetadataMem = NULL;
     }


### PR DESCRIPTION
meta data stream buffers gets allocated during
openCamera and gets deallocated during closeCamera
only if corresponding channel (preview) exist,
channel deallocates the stream memory. if closeCamera
happens just after openCamera in this case preview
channel doesn't exist so memory doesn't get deallocated,
so to fix this issue adding explicit deallocate call
to meta data memory.

Change-Id: I3fb52c254af31ad149ac8cb7565ba6289a452415
