### PR TITLE
QCamera2: Fix memory leak due to thread join.

### DIFF
--- a/QCamera2/HAL/QCameraStream.cpp
+++ b/QCamera2/HAL/QCameraStream.cpp
@@ -1840,6 +1840,14 @@ int32_t QCameraStream::releaseBuffs()
 {
     int rc = NO_ERROR;
 
+    if (mBufAllocPid != 0) {
+        cond_signal(true);
+        CDBG_HIGH("%s: wait for buf allocation thread dead", __func__);
+        pthread_join(mBufAllocPid, NULL);
+        mBufAllocPid = 0;
+        CDBG_HIGH("%s: return from buf allocation thread", __func__);
+    }
+
     if (mStreamInfo->streaming_mode == CAM_STREAMING_MODE_BATCH) {
         return releaseBatchBufs(NULL);
     }


### PR DESCRIPTION
Issue:
Buffer alloc routine is a joinable thread, which needs to be joined
after execution. But due to missing join in one case, memory leak
was happening of 1MB in VSS and 12kB in PSS.

Fix:
Join the buffer alloc routine during stream destruction.

Change-Id: Ic69819cc009a43bdb6abab2821e843e686067b07
CRs-Fixed: 1050988