### PR TITLE
QCamera2: HAL3: Restart daemon and mediaserver when buffer is lost.

### DIFF
--- a/QCamera2/HAL3/QCamera3HWI.cpp
+++ b/QCamera2/HAL3/QCamera3HWI.cpp
@@ -450,6 +450,7 @@ QCamera3HardwareInterface::QCamera3HardwareInterface(uint32_t cameraId,
 QCamera3HardwareInterface::~QCamera3HardwareInterface()
 {
     LOGD("E");
+    bool hasPendingBuffers = (mPendingBuffersMap.num_buffers > 0);
 
     /* Turn off current power hint before acquiring perfLock in case they
      * conflict with each other */
@@ -521,6 +522,15 @@ QCamera3HardwareInterface::~QCamera3HardwareInterface()
     /* Clean up all channels */
     if (mCameraInitialized) {
         if(!mFirstConfiguration){
+            clear_metadata_buffer(mParameters);
+
+            // Check if there is still pending buffer not yet returned.
+            if (hasPendingBuffers) {
+                uint8_t restart = TRUE;
+                ADD_SET_PARAM_ENTRY_TO_BATCH(mParameters, CAM_INTF_META_DAEMON_RESTART,
+                        restart);
+            }
+
             //send the last unconfigure
             cam_stream_size_info_t stream_config_info;
             memset(&stream_config_info, 0, sizeof(cam_stream_size_info_t));
@@ -569,6 +579,12 @@ QCamera3HardwareInterface::~QCamera3HardwareInterface()
     pthread_cond_destroy(&mBuffersCond);
 
     pthread_mutex_destroy(&mMutex);
+
+    if (hasPendingBuffers) {
+        ALOGE("%s: Not all buffers are returned. Aborting...", __func__);
+        abort();
+    }
+
     LOGD("X");
 }
 

--- a/QCamera2/stack/common/cam_intf.h
+++ b/QCamera2/stack/common/cam_intf.h
@@ -599,7 +599,7 @@ typedef struct {
 } cam_stream_img_prop_t;
 
 typedef struct {
-    uint8_t enableStream; /*0 – stop and 1-start */
+    uint8_t enableStream; /*0 Â– stop and 1-start */
 } cam_request_frames;
 
 typedef struct {
@@ -1008,6 +1008,7 @@ typedef struct {
     INCLUDE(CAM_INTF_META_REPROCESS_FLAGS,              uint8_t,                     1);
     INCLUDE(CAM_INTF_PARM_JPEG_ENCODE_CROP,             cam_stream_crop_info_t,      1);
     INCLUDE(CAM_INTF_PARM_JPEG_SCALE_DIMENSION,         cam_dimension_t,             1);
+    INCLUDE(CAM_INTF_META_DAEMON_RESTART,               uint8_t,                     1);
 } metadata_data_t;
 
 /* Update clear_metadata_buffer() function when a new is_xxx_valid is added to

--- a/QCamera2/stack/common/cam_types.h
+++ b/QCamera2/stack/common/cam_types.h
@@ -2203,6 +2203,8 @@ typedef enum {
     /* Number of streams and size of streams in
        current configuration for pic res*/
     CAM_INTF_META_STREAM_INFO_FOR_PIC_RES,
+    /* Whether HAL has run into DRAIN error */
+    CAM_INTF_META_DAEMON_RESTART
     CAM_INTF_PARM_MAX
 } cam_intf_parm_type_t;
 


### PR DESCRIPTION
When there are buffers not returned during closeCamera, restart
both daemon and mediaserver to reclaim leaked memory.

Bug: 25149843

Change-Id: I5283d37e04ab6e7b0305db5821a38a83f3ae5126