### PR TITLE
Delay opening the camera until capabilities are available

### DIFF
--- a/QCamera2/HAL/QCamera2HWI.cpp
+++ b/QCamera2/HAL/QCamera2HWI.cpp
@@ -1867,7 +1867,7 @@ int QCamera2HardwareInterface::openCamera()
 			// If we got capabilities or if the timeout of 10 seconds occurs, break
 			if((gCamCapability[mCameraId]->preview_sizes_tbl[0].width > 0 && gCamCapability[mCameraId]->preview_sizes_tbl[0].height > 0) || nTimeout >= 10000)
 			{
-				ALOGE("CameraShit: Getting capabilities succeeded.");
+				ALOGI("camera_open: Getting capabilities succeeded.");
 				break;
 			}
 			

--- a/QCamera2/HAL/QCamera2HWI.cpp
+++ b/QCamera2/HAL/QCamera2HWI.cpp
@@ -42,6 +42,7 @@
 #include <utils/RefBase.h>
 #include <QServiceUtils.h>
 #include <dlfcn.h>
+#include <time.h>
 
 #include "QCamera2HWI.h"
 #include "QCameraBufferMaps.h"
@@ -1840,18 +1841,49 @@ int QCamera2HardwareInterface::openCamera()
     } else {
         CDBG_HIGH("%s: Capabilities are not initialized. Initializing them now.", __func__);
 
-        rc = camera_open((uint8_t)mCameraId, &mCameraHandle);
-        if (rc) {
-            ALOGE("camera_open failed. rc = %d, mCameraHandle = %p", rc, mCameraHandle);
-            return rc;
-        }
+		// Sleep 100 ms
+		unsigned long milisec = 100;
+		struct timespec req = { 0, 0 };
+		time_t sec = (int)(milisec / 1000);
+		milisec = milisec - (sec * 1000);
+		req.tv_sec = sec;
+		req.tv_nsec = milisec * 1000000L;
+		
+		unsigned int nTimeout = 0;
+		while(true)
+		{
+			rc = camera_open((uint8_t)mCameraId, &mCameraHandle);
+			if (rc) {
+				ALOGE("camera_open failed. rc = %d, mCameraHandle = %p", rc, mCameraHandle);
+				return rc;
+			}
 
-        if(NO_ERROR != initCapabilities(mCameraId,mCameraHandle)) {
-            ALOGE("initCapabilities failed.");
-            rc = UNKNOWN_ERROR;
-            goto error_exit;
-        }
-
+			if(NO_ERROR != initCapabilities(mCameraId,mCameraHandle)) {
+				ALOGE("initCapabilities failed.");
+				rc = UNKNOWN_ERROR;
+				goto error_exit;
+			}
+			
+			// If we got capabilities or if the timeout of 10 seconds occurs, break
+			if((gCamCapability[mCameraId]->preview_sizes_tbl[0].width > 0 && gCamCapability[mCameraId]->preview_sizes_tbl[0].height > 0) || nTimeout >= 10000)
+			{
+				ALOGE("CameraShit: Getting capabilities succeeded.");
+				break;
+			}
+			
+			if(mJpegClientHandle) 
+			{
+				deinitJpegHandle();
+			}
+			
+			mCameraHandle->ops->close_camera(mCameraHandle->camera_handle);
+			mCameraHandle = NULL;
+			
+			// Sleep
+			nTimeout += milisec;
+			nanosleep(&req, NULL);
+		}
+		
         mCameraHandle->ops->register_event_notify(mCameraHandle->camera_handle,
                 camEvtHandle,
                 (void *) this);


### PR DESCRIPTION
In my tests most of the time on boot, the camera was opened before there were capabilities available. This patch tries reopening the camera until they are either available or ten seconds have passed.