### PR TITLE
Camera3: Change the PREVIEW_FORMAT to be the same as VIDEO_FORMAT

### DIFF
--- a/QCamera2/HAL3/QCamera3Channel.cpp
+++ b/QCamera2/HAL3/QCamera3Channel.cpp
@@ -588,10 +588,10 @@ cam_format_t QCamera3Channel::getStreamDefaultFormat(cam_stream_type_t type)
             if (pFormat == 1) {
                 streamFormat = CAM_FORMAT_YUV_420_NV12_UBWC;
             } else {
-                streamFormat = CAM_FORMAT_YUV_420_NV21;
+                streamFormat = CAM_FORMAT_YUV_420_NV12_VENUS;
             }
         } else {
-            streamFormat = CAM_FORMAT_YUV_420_NV21;
+            streamFormat = CAM_FORMAT_YUV_420_NV12_VENUS;
         }
         break;
     case CAM_STREAM_TYPE_VIDEO:


### PR DESCRIPTION
This improves the camera power usage by utilizing CPP output
duplication for the 1080p recording usecase

Note: NV12_VENUS for preview is the same as NV12 for recording

Change-Id: Ie58acfc35d4dfb60f4e2dd1fbbcbe04cbe5c27cf