### PR TITLE
QCamera2: HAL3: Clear metadata before last unconfigure

### DIFF
--- a/QCamera2/HAL3/QCamera3HWI.cpp
+++ b/QCamera2/HAL3/QCamera3HWI.cpp
@@ -455,6 +455,7 @@ QCamera3HardwareInterface::~QCamera3HardwareInterface()
             memset(&stream_config_info, 0, sizeof(cam_stream_size_info_t));
             stream_config_info.buffer_info.min_buffers = MIN_INFLIGHT_REQUESTS;
             stream_config_info.buffer_info.max_buffers = MAX_INFLIGHT_REQUESTS;
+            clear_metadata_buffer(mParameters);
             ADD_SET_PARAM_ENTRY_TO_BATCH(mParameters, CAM_INTF_META_STREAM_INFO,
                     stream_config_info);
             int rc = mCameraHandle->ops->set_parms(mCameraHandle->camera_handle, mParameters);


### PR DESCRIPTION
Issue:
When camera preview is in torch mode and while camera is
getting closed, sometimes the flash re-flashes again for
fraction of a second.

Fix:
In QCamera3HardwareInterface destructor, while sending
last unconfigure stream info, clear the metadata buffer.
Otherwise, previous per frame params were passed to MCT
and in turn to sensor. Sensor gets TORCH LED mode and
flash is fired.

Change-Id: Id0b967f676d30dc6d9d96fbfbdf3f8ddf185499a
CRs-Fixed: 1031478