### PR TITLE
QCamera2/HAL3: Change video colorspace to 601

### DIFF
--- a/QCamera2/HAL3/QCamera3Mem.cpp
+++ b/QCamera2/HAL3/QCamera3Mem.cpp
@@ -650,8 +650,7 @@ int QCamera3GrallocMemory::registerBuffer(buffer_handle_t *buffer,
     status_t ret = NO_ERROR;
     struct ion_fd_data ion_info_fd;
     void *vaddr = NULL;
-    int32_t colorSpace =
-            (type == CAM_STREAM_TYPE_VIDEO) ? ITU_R_709 : ITU_R_601_FR;
+    int32_t colorSpace = ITU_R_601_FR;
     int32_t idx = -1;
 
     CDBG(" %s : E ", __FUNCTION__);


### PR DESCRIPTION
ISP generates 601 colorspace stream. IQ evaluation from
system team recommends usage of 601 even at the encoder
output.

Change-Id: I3e16ee1c0eff487a8e5c845e348308ec21e21e9f