### PR TITLE
QCamera2/HAL3: Advertize correct timestamp source

### DIFF
--- a/QCamera2/HAL3/QCamera3HWI.cpp
+++ b/QCamera2/HAL3/QCamera3HWI.cpp
@@ -5297,7 +5297,10 @@ int QCamera3HardwareInterface::initStaticMetadata(uint32_t cameraId)
     staticInfo.update(ANDROID_TONEMAP_MAX_CURVE_POINTS,
                       &gCamCapability[cameraId]->max_tone_map_curve_points, 1);
 
-    uint8_t timestampSource = ANDROID_SENSOR_INFO_TIMESTAMP_SOURCE_UNKNOWN;
+    // SOF timestamp is based on monotonic_boottime. So advertize REALTIME timesource
+    // REALTIME defined in HAL3 API is same as linux's CLOCK_BOOTTIME
+    // Ref: kernel/...../msm_isp_util.c: msm_isp_get_timestamp: get_monotonic_boottime
+    uint8_t timestampSource = ANDROID_SENSOR_INFO_TIMESTAMP_SOURCE_REALTIME;
     staticInfo.update(ANDROID_SENSOR_INFO_TIMESTAMP_SOURCE,
             &timestampSource, 1);
 


### PR DESCRIPTION
Issue: Video and Display uses CLOCK_MONOTONIC as clock
reference for AV synchronization and rate controls.
But camera usecases require CLOCK_BOOTTIME (same as
CLOCK_MONOTONIC but includes the suspend time as well)
for synchronization with Gyro and other sensors. This
can cause clock source mismatch leading to black preview
or video

Solution: Camera framework provides a timestamp conversion
from BOOTTIME timestamps to MONOTONIC timestamps. From
HAL3, advertize time source correctly to trigger this
conversion in the framework

Change-Id: I4afbf856df752ba463d0f6b2050316d8387cf804
CRs-Fixed: 1049975