### PR TITLE
Enable msm8996 style perf limits on msm8998

### DIFF
--- a/QCamera2/Android.mk
+++ b/QCamera2/Android.mk
@@ -125,7 +125,7 @@ ifneq (,$(filter msm8996 sdm660 msm8998,$(TARGET_BOARD_PLATFORM)))
     LOCAL_CFLAGS += -DUBWC_PRESENT
 endif
 
-ifneq (,$(filter msm8996,$(TARGET_BOARD_PLATFORM)))
+ifneq (,$(filter msm8996 msm8998,$(TARGET_BOARD_PLATFORM)))
     LOCAL_CFLAGS += -DTARGET_MSM8996
 endif
 


### PR DESCRIPTION
"Fixes" actuator crash loop on maple builds