### PR TITLE
[CAMERA 57r1] mm-camera-test: Add liblog as shared library dependency

### DIFF
--- a/QCamera2/stack/mm-camera-test/Android.mk
+++ b/QCamera2/stack/mm-camera-test/Android.mk
@@ -86,7 +86,7 @@ endif
 LOCAL_CFLAGS += -Wall -Wextra -Werror
 
 LOCAL_SHARED_LIBRARIES:= \
-         libcutils libdl libmmcamera_interface
+         libcutils liblog libdl libmmcamera_interface
 
 LOCAL_MODULE_TAGS := optional
 


### PR DESCRIPTION
Android 8.0 does not inherit it automatically.