### PR TITLE
sony: camera: qomx_core: Add liblog as shared library dependency

### DIFF
--- a/mm-image-codec/qomx_core/Android.mk
+++ b/mm-image-codec/qomx_core/Android.mk
@@ -20,7 +20,7 @@ LOCAL_SRC_FILES := qomx_core.c
 
 LOCAL_MODULE           := libqomx_core
 LOCAL_PRELINK_MODULE   := false
-LOCAL_SHARED_LIBRARIES := libcutils libdl
+LOCAL_SHARED_LIBRARIES := libcutils libdl liblog
 
 LOCAL_32_BIT_ONLY := true
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
fixes

hardware/qcom/camera/mm-image-codec/qomx_core/qomx_core.c:80: error: undefined reference to '__android_log_print'
hardware/qcom/camera/mm-image-codec/qomx_core/qomx_core.c:101: error: undefined reference to '__android_log_print'
hardware/qcom/camera/mm-image-codec/qomx_core/qomx_core.c:125: error: undefined reference to '__android_log_print'
hardware/qcom/camera/mm-image-codec/qomx_core/qomx_core.c:194: error: undefined reference to '__android_log_print'

Signed-off-by: David Viteri <davidteri91@gmail.com>