### PR TITLE
QCamera2: HAL3: HDR related fixes.

### DIFF
--- a/QCamera2/HAL3/QCamera3PostProc.cpp
+++ b/QCamera2/HAL3/QCamera3PostProc.cpp
@@ -1231,7 +1231,6 @@ int32_t QCamera3PostProcessor::encodeFWKData(qcamera_hal3_jpeg_data_t *jpeg_job_
     memset(&crop, 0, sizeof(cam_rect_t));
     //TBD_later - Zoom event removed in stream
     //main_stream->getCropInfo(crop);
-
     // Set JPEG encode crop in reprocess frame metadata
     // If this JPEG crop info exist, encoder should do cropping
     IF_META_AVAILABLE(cam_stream_crop_info_t, jpeg_crop,
@@ -1584,6 +1583,7 @@ int32_t QCamera3PostProcessor::encodeData(qcamera_hal3_jpeg_data_t *jpeg_job_dat
     uint32_t jobId = 0;
     QCamera3Stream *main_stream = NULL;
     mm_camera_buf_def_t *main_frame = NULL;
+    cam_stream_parm_buffer_t param;
     QCamera3Channel *srcChannel = NULL;
     mm_camera_super_buf_t *recvd_frame = NULL;
     metadata_buffer_t *metadata = NULL;
@@ -1773,7 +1773,26 @@ int32_t QCamera3PostProcessor::encodeData(qcamera_hal3_jpeg_data_t *jpeg_job_dat
     memset(&crop, 0, sizeof(cam_rect_t));
     //TBD_later - Zoom event removed in stream
     //main_stream->getCropInfo(crop);
-
+    crop.left = 0;
+    crop.top = 0;
+    crop.height = src_dim.height;
+    crop.width = src_dim.width;
+    if (jpeg_settings->hdr_snapshot) {
+       memset(&param, 0, sizeof(cam_stream_parm_buffer_t));
+       param.type = CAM_STREAM_PARAM_TYPE_GET_OUTPUT_CROP;
+       ret = main_stream->getParameter(param);
+       if (ret != NO_ERROR) {
+          LOGE("%s: stream getParameter for reprocess failed", __func__);
+       } else {
+           for (int i = 0; i < param.outputCrop.num_of_streams; i++) {
+              if (param.outputCrop.crop_info[i].stream_id
+                  == main_stream->getMyServerID()) {
+                     crop = param.outputCrop.crop_info[i].crop;
+                     main_stream->setCropInfo(crop);
+              }
+           }
+         }
+    }
     // Set main dim job parameters and handle rotation
     if (!needJpegExifRotation && (jpeg_settings->jpeg_orientation == 90 ||
             jpeg_settings->jpeg_orientation == 270)) {

--- a/QCamera2/HAL3/QCamera3Stream.cpp
+++ b/QCamera2/HAL3/QCamera3Stream.cpp
@@ -308,6 +308,7 @@ QCamera3Stream::QCamera3Stream(uint32_t camHandle,
     mMemVtbl.clean_buf = clean_buf;
     mMemVtbl.set_config_ops = NULL;
     memset(&mFrameLenOffset, 0, sizeof(mFrameLenOffset));
+    memset(&mCropInfo, 0, sizeof(cam_rect_t));
     memcpy(&mPaddingInfo, paddingInfo, sizeof(cam_padding_info_t));
 }
 
@@ -1185,6 +1186,52 @@ uint32_t QCamera3Stream::getMyServerID() {
     } else {
         return 0;
     }
+}
+
+
+/*===========================================================================
+ * FUNCTION   : setCropInfo
+ *
+ * DESCRIPTION: set crop info of the stream
+ *
+ * PARAMETERS :
+ *   @crop    : struct to store new crop info
+ *
+ * RETURN     : int32_t type of status
+ *              NO_ERROR  -- success
+ *              none-zero failure code
+ *==========================================================================*/
+int32_t QCamera3Stream::setCropInfo(cam_rect_t crop)
+{
+    mCropInfo = crop;
+    return NO_ERROR;
+}
+
+
+/*===========================================================================
+ * FUNCTION   : getParameter
+ *
+ * DESCRIPTION: get stream based parameters
+ *
+ * PARAMETERS :
+ *   @param   : ptr to parameters to be red
+ *
+ * RETURN     : int32_t type of status
+ *              NO_ERROR  -- success
+ *              none-zero failure code
+ *==========================================================================*/
+int32_t QCamera3Stream::getParameter(cam_stream_parm_buffer_t &param)
+{
+    int32_t rc = NO_ERROR;
+    mStreamInfo->parm_buf = param;
+    rc = mCamOps->get_stream_parms(mCamHandle,
+                                   mChannelHandle,
+                                   mHandle,
+                                   &mStreamInfo->parm_buf);
+    if (rc == NO_ERROR) {
+        param = mStreamInfo->parm_buf;
+    }
+    return rc;
 }
 
 /*===========================================================================

--- a/QCamera2/HAL3/QCamera3Stream.h
+++ b/QCamera2/HAL3/QCamera3Stream.h
@@ -87,6 +87,8 @@ public:
     int32_t getFrameOffset(cam_frame_len_offset_t &offset);
     int32_t getFrameDimension(cam_dimension_t &dim);
     int32_t getFormat(cam_format_t &fmt);
+    int32_t setCropInfo(cam_rect_t crop);
+    int32_t getParameter(cam_stream_parm_buffer_t &param);
     QCamera3StreamMem *getStreamBufs() {return mStreamBufs;};
     uint32_t getMyServerID();
 
@@ -122,6 +124,7 @@ private:
     QCamera3StreamMem *mStreamBufs;
     mm_camera_buf_def_t *mBufDefs;
     cam_frame_len_offset_t mFrameLenOffset;
+    cam_rect_t mCropInfo;
     cam_padding_info_t mPaddingInfo;
     QCamera3Channel *mChannel;
     Mutex mLock;    //Lock controlling access to 'mBufDefs'


### PR DESCRIPTION
Issue:
1) Since HDR happens after CPP, crop has to
be done by JPEG module , but the crop values sent
by HAL are always zero.

2) Backend expects specific order for HDR snapshot
exposure(0,-6,+6) and in current implementation
it is (-6,0,+6).
Fix:
1) HDR updates the crop information to HAL as
part of PARM_STREAM_BUF event.Read the crop
values sent by backend and append these values
while sending params to jpeg session.

2) Send the exposure values in order, as expected
by backend.
Change-Id: I01008770e5cd48499f91eeef1c041572b35a8ae3