### PR TITLE
QCamera2: Remove absolute path for shimlayer lib

### DIFF
--- a/QCamera2/stack/common/mm_camera_shim.h
+++ b/QCamera2/stack/common/mm_camera_shim.h
@@ -35,7 +35,7 @@
 /*
  * MCT shim layer APIs
  */
-#define SHIMLAYER_LIB "/system/vendor/lib/libmmcamera2_mct_shimlayer.so"
+#define SHIMLAYER_LIB "libmmcamera2_mct_shimlayer.so"
 
 struct cam_shim_packet;
 


### PR DESCRIPTION
there is no need for an absolute path here since the lib can be found
dynamically