### PR TITLE
QCamera2: Increase EXIF table entries.

### DIFF
--- a/QCamera2/HAL/QCameraPostProc.h
+++ b/QCamera2/HAL/QCameraPostProc.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2016, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2012-2017, The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -128,7 +128,7 @@ typedef struct {
     qcamera_release_data_t   release_data; // any data needs to be release after notify
 } qcamera_data_argm_t;
 
-#define MAX_EXIF_TABLE_ENTRIES 17
+#define MAX_EXIF_TABLE_ENTRIES 50
 class QCameraExif
 {
 public:

--- a/QCamera2/HAL3/QCamera3PostProc.h
+++ b/QCamera2/HAL3/QCamera3PostProc.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2016, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2012-2017, The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -87,7 +87,7 @@ typedef struct {
     uint32_t frameNumber;
 } qcamera_hal3_pp_buffer_t;
 
-#define MAX_HAL3_EXIF_TABLE_ENTRIES 23
+#define MAX_HAL3_EXIF_TABLE_ENTRIES 50
 class QCamera3Exif
 {
 public:


### PR DESCRIPTION
Issue:
With thirdparty APP, the picture is
rotated to 90 degrees when GPS
location is on due to EXIF table
exceeds the size limit.

Fix:
Increase MAX_EXIF_TABLE_ENTRIES to 50 in
align with JPEG encoder.

CRs-Fixed: 2054157

Change-Id: I45f2b466c1801418dce00458085f2e8a9acb8f6f