### PR TITLE
[CAMERA 57r1] QCamera2: Use QCOM_MEDIA_ROOT for media headers

### DIFF
--- a/QCamera2/Android.mk
+++ b/QCamera2/Android.mk
@@ -103,8 +103,8 @@ LOCAL_C_INCLUDES := \
         $(LOCAL_PATH)/util \
         $(LOCAL_PATH)/HAL3 \
         hardware/libhardware/include/hardware \
-        hardware/qcom/media/msm8998/libstagefrighthw \
-        hardware/qcom/media/msm8998/mm-core/inc \
+        $(QCOM_MEDIA_ROOT)/libstagefrighthw \
+        $(QCOM_MEDIA_ROOT)/mm-core/inc \
         system/core/include/cutils \
         system/core/include/system \
         system/media/camera/include/system


### PR DESCRIPTION
We declare QCOM_MEDIA_ROOT in our sony-common Android.mk
and we can use this variable to dynamically choose the HAL headers
location for every future release, instead of changing it manually
everytime.
This also helps development when we need to change media HAL path.


TESTED: Built Android 8.0 with msm8998 AOSP HAL and CAF HAL by changing the QCOM_MEDIA_ROOT variable in device-sony-common/Android.mk