### PR TITLE
QCamera2: HAL3: Set timestamp source based on sensor sync availability

### DIFF
--- a/QCamera2/HAL3/QCamera3HWI.cpp
+++ b/QCamera2/HAL3/QCamera3HWI.cpp
@@ -8091,10 +8091,9 @@ int QCamera3HardwareInterface::initStaticMetadata(uint32_t cameraId)
     staticInfo.update(ANDROID_TONEMAP_MAX_CURVE_POINTS,
             &gCamCapability[cameraId]->max_tone_map_curve_points, 1);
 
-    // SOF timestamp is based on monotonic_boottime. So advertize REALTIME timesource
-    // REALTIME defined in HAL3 API is same as linux's CLOCK_BOOTTIME
-    // Ref: kernel/...../msm_isp_util.c: msm_isp_get_timestamp: get_monotonic_boottime
-    uint8_t timestampSource = ANDROID_SENSOR_INFO_TIMESTAMP_SOURCE_REALTIME;
+    uint8_t timestampSource = (gCamCapability[cameraId]->timestamp_calibrated ?
+            ANDROID_SENSOR_INFO_TIMESTAMP_SOURCE_REALTIME :
+            ANDROID_SENSOR_INFO_TIMESTAMP_SOURCE_UNKNOWN);
     staticInfo.update(ANDROID_SENSOR_INFO_TIMESTAMP_SOURCE,
             &timestampSource, 1);
 

--- a/QCamera2/stack/common/cam_intf.h
+++ b/QCamera2/stack/common/cam_intf.h
@@ -673,6 +673,9 @@ typedef struct cam_capability{
 
     /* sensor rotation */
     int32_t sensor_rotation;
+
+    /* Whether camera timestamp is calibrated with sensor */
+    uint8_t timestamp_calibrated;
 } cam_capability_t;
 
 typedef enum {


### PR DESCRIPTION
Only set timestamp source to be REALTIME if sensor sync is available, in
other words, if timestamp is calibrated.

Bug: 30471814
Change-Id: I69dcea59f2c77ad2246ef240fd83c3ebab90af32