### PR TITLE
QCamera2: Fix include directory for HAL1 header files

### DIFF
--- a/QCamera2/Android.mk
+++ b/QCamera2/Android.mk
@@ -111,7 +111,7 @@ LOCAL_C_INCLUDES := \
 
 #HAL 1.0 Include paths
 LOCAL_C_INCLUDES += \
-        hardware/qcom/camera/QCamera2/HAL
+        hardware/sony/camera/QCamera2/HAL
 
 ifeq ($(TARGET_COMPILE_WITH_MSM_KERNEL),true)
 LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include


### PR DESCRIPTION
Fix include directory for HAL1 header files