### PR TITLE
[CAMERA] QCamera2: Add support for the Camera Augmented Sensing Helper ToF

### DIFF
--- a/QCamera2/Android.mk
+++ b/QCamera2/Android.mk
@@ -141,6 +141,11 @@ ifeq ($(TARGET_TS_MAKEUP),true)
 LOCAL_SHARED_LIBRARIES += libts_face_beautify_hal libts_detected_face_hal
 endif
 
+ifeq ($(TARGET_USES_CASH_EXTENSION), true)
+LOCAL_SHARED_LIBRARIES += libcashctl
+LOCAL_CFLAGS += -DTARGET_HAS_CASH
+endif
+
 LOCAL_STATIC_LIBRARIES := android.hardware.camera.common@1.0-helper
 
 

--- a/QCamera2/HAL3/QCamera3HWI.cpp
+++ b/QCamera2/HAL3/QCamera3HWI.cpp
@@ -61,6 +61,13 @@ extern "C" {
 #include "mm_camera_dbg.h"
 }
 
+// Camera Augmented Sensing Helper
+#ifdef TARGET_HAS_CASH
+extern "C" {
+#include <cashsvr/cash_ext.h>
+}
+#endif
+
 using namespace android;
 
 namespace qcamera {
@@ -389,6 +396,9 @@ camera3_device_ops_t QCamera3HardwareInterface::mCameraOps = {
 
 // initialise to some default value
 uint32_t QCamera3HardwareInterface::sessionId[] = {0xDEADBEEF, 0xDEADBEEF, 0xDEADBEEF};
+
+uint8_t QCamera3HardwareInterface::tofAfState = 0;
+bool QCamera3HardwareInterface::tof_focusing = false;
 
 /*===========================================================================
  * FUNCTION   : QCamera3HardwareInterface
@@ -994,6 +1004,11 @@ int QCamera3HardwareInterface::openCamera()
 
     LOGH("mCameraId=%d",mCameraId);
 
+#ifdef TARGET_HAS_CASH
+    if (mCameraId == 0)
+	cash_tof_start(true);
+#endif
+
     return NO_ERROR;
 }
 
@@ -1016,6 +1031,11 @@ int QCamera3HardwareInterface::closeCamera()
 
     LOGI("[KPI Perf]: E PROFILE_CLOSE_CAMERA camera id %d",
              mCameraId);
+
+#ifdef TARGET_HAS_CASH
+    if (mCameraId == 0)
+	cash_tof_start(false);
+#endif
 
     // unmap memory for related cam sync buffer
     mCameraHandle->ops->unmap_buf(mCameraHandle->camera_handle,
@@ -7222,10 +7242,17 @@ QCamera3HardwareInterface::translateFromHalMetadata(
                 hAeRegions->rect.height);
     }
 
+
     IF_META_AVAILABLE(uint32_t, afState, CAM_INTF_META_AF_STATE, metadata) {
-        uint8_t fwk_afState = (uint8_t) *afState;
-        camMetadata.update(ANDROID_CONTROL_AF_STATE, &fwk_afState, 1);
-        LOGD("urgent Metadata : ANDROID_CONTROL_AF_STATE %u", *afState);
+        if (!tof_focusing) {
+            uint8_t fwk_afState = (uint8_t) *afState;
+            camMetadata.update(ANDROID_CONTROL_AF_STATE, &fwk_afState, 1);
+            LOGD("urgent Metadata : ANDROID_CONTROL_AF_STATE %u", *afState);
+        } else {
+            camMetadata.update(ANDROID_CONTROL_AF_STATE, &tofAfState, 1);
+            ALOGE("urgent Metadata : ANDROID_CONTROL_AF_STATE %u", tofAfState);
+            tofAfState = tofAfState == 0 ? 4 : 0;
+        }
     }
 
     IF_META_AVAILABLE(float, focusDistance, CAM_INTF_META_LENS_FOCUS_DISTANCE, metadata) {
@@ -7718,8 +7745,10 @@ QCamera3HardwareInterface::translateCbUrgentMetadataToResultMetadata
 
     IF_META_AVAILABLE(uint32_t, ae_state, CAM_INTF_META_AEC_STATE, metadata) {
         uint8_t fwk_ae_state = (uint8_t) *ae_state;
+        if (fwk_ae_state != 2 && fwk_ae_state != 4 && tof_focusing)
+            fwk_ae_state = 2;
         camMetadata.update(ANDROID_CONTROL_AE_STATE, &fwk_ae_state, 1);
-        LOGD("urgent Metadata : ANDROID_CONTROL_AE_STATE %u", *ae_state);
+        LOGD("urgent Metadata : ANDROID_CONTROL_AE_STATE %u", fwk_ae_state);
     }
 
     IF_META_AVAILABLE(uint32_t, focusMode, CAM_INTF_PARM_FOCUS_MODE, metadata) {
@@ -11510,7 +11539,34 @@ int QCamera3HardwareInterface::translateToHalMetadata
     property_get("persist.camera.af.infinity", af_value, "0");
 
     uint8_t fwk_focusMode = 0;
-    if (atoi(af_value) == 0) {
+    bool use_tof = false;
+#ifdef TARGET_HAS_CASH
+    tof_focusing = false;
+    if (atoi(af_value) == 0 && mCameraId == 0) {
+        if (frame_settings.exists(ANDROID_CONTROL_AF_MODE)) {
+            /* Don't use ToF if we are in manual focus mode */
+            fwk_focusMode =
+                    frame_settings.find(ANDROID_CONTROL_AF_MODE).data.u8[0];
+            if (fwk_focusMode != ANDROID_CONTROL_AF_MODE_OFF)
+                use_tof = cash_is_tof_in_range();
+            else
+                use_tof = false;
+            ALOGI("ToF: use_tof = %d", use_tof);
+            if (use_tof) {
+                float focalDistance = (float)(
+                                (float)cash_get_focus() / 1000000.0f);
+                ALOGI("Setting focal distance %f from ToF", focalDistance);
+                ADD_SET_PARAM_ENTRY_TO_BATCH(hal_metadata,
+                                CAM_INTF_PARM_FOCUS_MODE, CAM_FOCUS_MODE_OFF);
+                ADD_SET_PARAM_ENTRY_TO_BATCH(hal_metadata,
+                                CAM_INTF_META_LENS_FOCUS_DISTANCE,
+                                focalDistance);
+                tof_focusing = true;
+            }
+        }
+    }
+#endif
+    if (atoi(af_value) == 0 && !use_tof) {
         if (frame_settings.exists(ANDROID_CONTROL_AF_MODE)) {
             fwk_focusMode = frame_settings.find(ANDROID_CONTROL_AF_MODE).data.u8[0];
             int val = lookupHalName(FOCUS_MODES_MAP, METADATA_MAP_SIZE(FOCUS_MODES_MAP),
@@ -11524,7 +11580,7 @@ int QCamera3HardwareInterface::translateToHalMetadata
                 }
             }
         }
-    } else {
+    } else if (!use_tof) {
         uint8_t focusMode = (uint8_t)CAM_FOCUS_MODE_INFINITY;
         LOGE("Focus forced to infinity %d", focusMode);
         if (ADD_SET_PARAM_ENTRY_TO_BATCH(hal_metadata, CAM_INTF_PARM_FOCUS_MODE, focusMode)) {
@@ -11538,7 +11594,9 @@ int QCamera3HardwareInterface::translateToHalMetadata
         if (ADD_SET_PARAM_ENTRY_TO_BATCH(hal_metadata, CAM_INTF_META_LENS_FOCUS_DISTANCE,
                 focalDistance)) {
             rc = BAD_VALUE;
-        }
+        } else {
+            LOGD("MF focalDistance = %f", focalDistance);
+	}
     }
 
     if (frame_settings.exists(ANDROID_CONTROL_AE_ANTIBANDING_MODE)) {

--- a/QCamera2/HAL3/QCamera3HWI.h
+++ b/QCamera2/HAL3/QCamera3HWI.h
@@ -179,6 +179,8 @@ public:
     static int flush(const struct camera3_device *);
     static int close_camera_device(struct hw_device_t* device);
 
+    static bool tof_focusing;
+    static uint8_t tofAfState;
 public:
     QCamera3HardwareInterface(uint32_t cameraId,
             const camera_module_callbacks_t *callbacks);


### PR DESCRIPTION
Support is added for CASH ToF. To enable it, it is needed to
declare TARGET_USES_CASH_EXTENSION.

Many thanks to @oshmoun for finding a way to get rid of
Open Camera related (and probably some other app) snapshot bugs.

Signed-off-by: oshmoun <oshmoun100@googlemail.com>