### PR TITLE
[CAMERA] Add kernel 4.9 media API compatibility

### DIFF
--- a/QCamera2/stack/common/mm_camera_interface.h
+++ b/QCamera2/stack/common/mm_camera_interface.h
@@ -32,6 +32,8 @@
 
 // System dependencies
 #include <media/msmb_camera.h>
+#include <linux/media.h>
+
 
 // Camera dependencies
 #include "cam_intf.h"
@@ -1019,4 +1021,8 @@ uint32_t get_aux_camera_handle(uint32_t handle);
 
 /*Validate 2 handle if it is belong to same instance of camera/channel/stream*/
 uint8_t validate_handle(uint32_t src_handle, uint32_t handle);
+
+int mm_camera_util_match_subdev_type(struct media_entity_desc entity,
+     uint32_t gid, uint32_t type);
+
 #endif /*__MM_CAMERA_INTERFACE_H__*/

--- a/QCamera2/stack/mm-camera-interface/Android.mk
+++ b/QCamera2/stack/mm-camera-interface/Android.mk
@@ -58,6 +58,9 @@ LOCAL_CFLAGS += -include bionic/libc/kernel/common/linux/un.h
 endif
 
 LOCAL_CFLAGS += -Wall -Wextra -Werror
+ifeq ($(TARGET_KERNEL_VERSION), 4.9)
+LOCAL_CFLAGS += -DUSE_4_9_DEFS
+endif
 
 LOCAL_SRC_FILES := $(MM_CAM_FILES)
 

--- a/QCamera2/stack/mm-camera-interface/Android.mk
+++ b/QCamera2/stack/mm-camera-interface/Android.mk
@@ -58,7 +58,7 @@ LOCAL_CFLAGS += -include bionic/libc/kernel/common/linux/un.h
 endif
 
 LOCAL_CFLAGS += -Wall -Wextra -Werror
-ifeq ($(TARGET_KERNEL_VERSION), 4.9)
+ifeq ($(SOMC_KERNEL_VERSION), 4.9)
 LOCAL_CFLAGS += -DUSE_4_9_DEFS
 endif
 


### PR DESCRIPTION
The media API changed in k4.9: add compatibility and keep k4.4
compat by switching API calls with SOMC_KERNEL_VERSION barrier.