### PR TITLE
fix error in build when TARGET_SUPPORT_HAL1 is false

### DIFF
--- a/QCamera2/Android.mk
+++ b/QCamera2/Android.mk
@@ -33,7 +33,7 @@ LOCAL_SRC_FILES += \
         HAL3/QCamera3CropRegionMapper.cpp \
         HAL3/QCamera3StreamMem.cpp
 
-LOCAL_CFLAGS := -Wall -Wextra -Werror
+LOCAL_CFLAGS := -Wall -Wextra -Werror -Wno-unused-parameter
 LOCAL_CFLAGS += -DFDLEAK_FLAG
 LOCAL_CFLAGS += -DMEMLEAK_FLAG
 #HAL 1.0 source


### PR DESCRIPTION
hardware/qcom/camera/QCamera2/QCamera2Factory.cpp:499:69: error: unused parameter 'hw_device' [-Werror,-Wunused-parameter]
        int32_t cameraId, uint32_t halVersion, struct hw_device_t** hw_device)
                                                                    ^
1 error generated.

Signed-off-by: David Viteri <davidteri91@gmail.com>