### PR TITLE
[CAMERA] QCamera3HWI: CASH-ToF: Fix in-range evaluation

### DIFF
--- a/QCamera2/HAL3/QCamera3HWI.cpp
+++ b/QCamera2/HAL3/QCamera3HWI.cpp
@@ -11588,7 +11588,7 @@ int QCamera3HardwareInterface::translateToHalMetadata
             fwk_focusMode =
                     frame_settings.find(ANDROID_CONTROL_AF_MODE).data.u8[0];
             if (fwk_focusMode != ANDROID_CONTROL_AF_MODE_OFF)
-                use_tof = cash_is_tof_in_range();
+                use_tof = ((cash_is_tof_in_range() > 0) ? true : false);
             else
                 use_tof = false;
             ALOGI("ToF: use_tof = %d", use_tof);


### PR DESCRIPTION
The cash_is_tof_in_range function returns an int value
that may be less than zero.
Avoid unpredictable behavior by adding a value check
to the function's return value.