### PR TITLE
sdllvm-common-defs: Stop using obsolete ANDROID_BUILD_TOP

### DIFF
--- a/QCamera2/sdllvm-common-defs.mk
+++ b/QCamera2/sdllvm-common-defs.mk
@@ -6,38 +6,24 @@ ifeq ($(CAMERA_USE_SDCLANG),)
   CAMERA_USE_SDCLANG := true
   CAMERA_USE_SDCLANG_2 := false
 
-  # Append Android build top if path is not absolute.
-  ifneq ($(SDCLANG_PATH),$(filter /%,$(SDCLANG_PATH)))
-    CAMERA_SDCLANG_ABS_PATH := $(ANDROID_BUILD_TOP)/$(SDCLANG_PATH)
-  else
-    CAMERA_SDCLANG_ABS_PATH := $(SDCLANG_PATH)
-  endif
-
-  ifneq ($(wildcard $(CAMERA_SDCLANG_ABS_PATH)),)
-    CAMERA_SDCLANG_VERSION := $(shell $(CAMERA_SDCLANG_ABS_PATH)/llvm-config --version)
+  ifneq ($(wildcard $(SDCLANG_PATH)),)
+    CAMERA_SDCLANG_VERSION := $(shell $(SDCLANG_PATH)/llvm-config --version)
 
     ifneq ($(shell expr $(CAMERA_SDCLANG_VERSION) \>= 4), 1)
-      # Append Android build top if path is not absolute.
-      ifneq ($(SDCLANG_PATH_2),$(filter /%,$(SDCLANG_PATH_2)))
-      CAMERA_SDCLANG_ABS_PATH_2 := $(ANDROID_BUILD_TOP)/$(SDCLANG_PATH_2)
-      else
-      CAMERA_SDCLANG_ABS_PATH_2 := $(SDCLANG_PATH_2)
-      endif
-
-      ifneq ($(wildcard $(CAMERA_SDCLANG_ABS_PATH_2)),)
-	CAMERA_SDCLANG_VERSION_2 := $(shell $(CAMERA_SDCLANG_ABS_PATH_2)/llvm-config --version)
+      ifneq ($(wildcard $(SDCLANG_PATH_2)),)
+	CAMERA_SDCLANG_VERSION_2 := $(shell $(SDCLANG_PATH_2)/llvm-config --version)
 	ifeq ($(shell expr $(CAMERA_SDCLANG_VERSION_2) \>= 4), 1)
 	  CAMERA_USE_SDCLANG := false
 	  CAMERA_USE_SDCLANG_2 := true
 	endif
       else
-	# CAMERA_SDCLANG_ABS_PATH_2 does not exist.
+	# SDCLANG_PATH_2 does not exist.
 	CAMERA_USE_SDCLANG_2 := false
       endif
     endif
 
   else
-  # CAMERA_SDCLANG_ABS_PATH does not exist.
+  # SDCLANG_PATH does not exist.
   CAMERA_USE_SDCLANG := false
   endif
 endif


### PR DESCRIPTION
Use of `ANDROID_BUILD_TOP` is discouraged and may result in build failures soon.
See https://android.googlesource.com/platform/build/+/android-9.0.0_r30/Changes.md#android_build_top

> In Android.mk files, you can always assume that the current directory
> is the root of the source tree