### PR TITLE
[Q-COMPAT] Makefiles: Remove "eng" from LOCAL_MODULE_TAGS

### DIFF
--- a/QCamera2/stack/common/leak/Android.mk
+++ b/QCamera2/stack/common/leak/Android.mk
@@ -19,7 +19,7 @@ endif
 LOCAL_SRC_FILES := fdleak.cpp memleak.cpp
 LOCAL_SHARED_LIBRARIES := libdl libcutils liblog
 LOCAL_MODULE := libhal_dbg
-LOCAL_MODULE_TAGS := optional eng
+LOCAL_MODULE_TAGS := optional
 
 LOCAL_VENDOR_MODULE := true
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
This has been deprecated for some time and will throw and error in Android Q