### PR TITLE
[VERIFYME] QCamera2: HAL: Change CDS mode to OFF by default.

### DIFF
--- a/QCamera2/HAL/QCameraParameters.cpp
+++ b/QCamera2/HAL/QCameraParameters.cpp
@@ -8694,7 +8694,7 @@ int32_t QCameraParameters::setCDSMode(const QCameraParameters& params)
         } else {
             char video_prop[PROPERTY_VALUE_MAX];
             memset(video_prop, 0, sizeof(video_prop));
-            property_get("persist.vendor.camera.video.CDS", video_prop, CDS_MODE_ON);
+            property_get("persist.vendor.camera.video.CDS", video_prop, CDS_MODE_OFF);
             int32_t cds_mode = lookupAttr(CDS_MODES_MAP, PARAM_MAP_SIZE(CDS_MODES_MAP),
                     video_prop);
             if (cds_mode != NAME_NOT_FOUND) {
@@ -8734,7 +8734,7 @@ int32_t QCameraParameters::setCDSMode(const QCameraParameters& params)
         } else {
             char prop[PROPERTY_VALUE_MAX];
             memset(prop, 0, sizeof(prop));
-            property_get("persist.vendor.camera.CDS", prop, CDS_MODE_ON);
+            property_get("persist.vendor.camera.CDS", prop, CDS_MODE_OFF);
             int32_t cds_mode = lookupAttr(CDS_MODES_MAP, PARAM_MAP_SIZE(CDS_MODES_MAP),
                     prop);
             if (cds_mode != NAME_NOT_FOUND) {

--- a/QCamera2/HAL3/QCamera3HWI.cpp
+++ b/QCamera2/HAL3/QCamera3HWI.cpp
@@ -10888,7 +10888,7 @@ camera_metadata_t* QCamera3HardwareInterface::translateCapabilityToMetadata(int 
     /* CDS default */
     char prop[PROPERTY_VALUE_MAX];
     memset(prop, 0, sizeof(prop));
-    property_get("persist.vendor.camera.CDS", prop, "Auto");
+    property_get("persist.vendor.camera.CDS", prop, "Off");
     cam_cds_mode_type_t cds_mode = CAM_CDS_MODE_AUTO;
     cds_mode = lookupProp(CDS_MAP, METADATA_MAP_SIZE(CDS_MAP), prop);
     if (CAM_CDS_MODE_MAX == cds_mode) {


### PR DESCRIPTION
Alternative to https://github.com/sonyxperiadev/device-sony-common/pull/618

Cherry-picked from https://source.codeaurora.org/quic/la/platform/hardware/qcom/camera/commit/?id=9eeafe30749482b8dbb14cbaeda6df59c5ec7b91

Issue:
CDS Mode by default set to ON causing ISP ping pong buffer
errors.

Fix:
Set CDS mode to OFF by defeualt as similar to previous SP's.