### PR TITLE
Allow implicit-fallthrough warnings locally

### DIFF
--- a/QCamera2/Android.mk
+++ b/QCamera2/Android.mk
@@ -43,6 +43,11 @@ ifeq ($(TARGET_SUPPORT_HAL1),false)
 LOCAL_CFLAGS += -DQCAMERA_HAL3_SUPPORT
 else
 LOCAL_CFLAGS += -DQCAMERA_HAL1_SUPPORT
+
+# Allow implicit fallthroughs in QCamera2HWI.cpp:6495 and
+# in QCameraStateMaschine.cpp until they are fixed.
+LOCAL_CFLAGS += -Wno-error=implicit-fallthrough
+
 LOCAL_SRC_FILES += \
         HAL/QCamera2HWI.cpp \
         HAL/QCameraMuxer.cpp \


### PR DESCRIPTION
Instead of trying to fix all these warnings, disable them until upstream fixes it.

https://android-review.googlesource.com/c/platform/hardware/qcom/camera/+/796152