### PR TITLE
[CAMERA] [8.11.r1] QCamera2: Disable HAL1 for legacy SoC

### DIFF
--- a/QCamera2/Android.mk
+++ b/QCamera2/Android.mk
@@ -197,7 +197,7 @@ ifeq ($(TARGET_HAS_LOW_RAM), true)
 LOCAL_CFLAGS += -DHAS_LOW_RAM
 endif
 
-ifneq (,$(filter $(TRINKET) msm8937_32go-userdebug, $(TARGET_BOARD_PLATFORM)))
+ifneq (,$(filter $(TRINKET) sdm660 msm8952 msm8996 msm8998 msm8937_32go-userdebug, $(TARGET_BOARD_PLATFORM)))
 LOCAL_CFLAGS += -DSUPPORT_ONLY_HAL3
 endif
 


### PR DESCRIPTION
Replicate the CAF commit from another branch and disable
HAL1 for SDM660. Also do it for other legacy SoCs, as they
will have the same quirk.