### PR TITLE
QCamera2: Define VANILLA_HAL definition regardless of multicam support

### DIFF
--- a/QCamera2/Android.mk
+++ b/QCamera2/Android.mk
@@ -80,17 +80,14 @@ LOCAL_CFLAGS += -DSYSTEM_HEADER_PREFIX=sys
 
 LOCAL_CFLAGS += -DHAS_MULTIMEDIA_HINTS -D_ANDROID
 
-ifeq ($(ENABLE_MULTICAM_SUPPORT), true)
-LOCAL_CFLAGS += -DUSE_HAL_3_5
-else
-
 ifeq ($(TARGET_USES_AOSP),true)
 LOCAL_CFLAGS += -DVANILLA_HAL
 endif
 
-ifeq (1,$(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) <= 23 ))" )))
+ifeq ($(ENABLE_MULTICAM_SUPPORT), true)
+LOCAL_CFLAGS += -DUSE_HAL_3_5
+else ifeq (1,$(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) <= 23 ))" )))
 LOCAL_CFLAGS += -DUSE_HAL_3_3
-endif
 endif
 
 #use media extension


### PR DESCRIPTION
These two flags are not related and the ifeq for TARGET_USES_AOSP was
accidentally inserted in the wrong spot. Fix the structure to make sure
we can compile without multicam support, too.

Fixes: 175ae96f7b4aeb96b7efdf2ccb5cd9e1a36a45bd