### PR TITLE
[LA.UM.8.11][DONOTMERGEYET] Disable lib2d (Make the HAL buildable)

### DIFF
--- a/QCamera2/HAL/QCameraParameters.cpp
+++ b/QCamera2/HAL/QCameraParameters.cpp
@@ -11771,17 +11771,6 @@ uint32_t QCameraParameters::getJpegExifRotation() {
 bool QCameraParameters::useJpegExifRotation() {
     char exifRotation[PROPERTY_VALUE_MAX];
 
-    property_get("persist.vendor.camera.exif.rotation", exifRotation, "off");
-
-    if (!strcmp(exifRotation, "on")) {
-        return true;
-    }
-
-    property_get("persist.vendor.camera.lib2d.rotation", exifRotation, "off");
-    if (!strcmp(exifRotation, "on")) {
-        return false;
-    }
-
     if (!(m_pCapability->qcom_supported_feature_mask & CAM_QCOM_FEATURE_ROTATION)) {
         return true;
     }

--- a/QCamera2/HAL/QCameraParameters.cpp
+++ b/QCamera2/HAL/QCameraParameters.cpp
@@ -11770,6 +11770,11 @@ uint32_t QCameraParameters::getJpegExifRotation() {
  *==========================================================================*/
 bool QCameraParameters::useJpegExifRotation() {
     char exifRotation[PROPERTY_VALUE_MAX];
+    property_get("persist.camera.exif.rotation", exifRotation, "off");
+
+    if (!strcmp(exifRotation, "on")) {
+        return true;
+    }
 
     if (!(m_pCapability->qcom_supported_feature_mask & CAM_QCOM_FEATURE_ROTATION)) {
         return true;

--- a/QCamera2/stack/Android.mk
+++ b/QCamera2/stack/Android.mk
@@ -3,6 +3,4 @@ include $(LOCAL_PATH)/mm-camera-interface/Android.mk
 include $(LOCAL_PATH)/mm-jpeg-interface/Android.mk
 include $(LOCAL_PATH)/mm-jpeg-interface/test/Android.mk
 include $(LOCAL_PATH)/mm-camera-test/Android.mk
-include $(LOCAL_PATH)/mm-lib2d-interface/Android.mk
 include $(LOCAL_PATH)/common/leak/Android.mk
-

--- a/QCamera2/stack/mm-jpeg-interface/Android.mk
+++ b/QCamera2/stack/mm-jpeg-interface/Android.mk
@@ -20,7 +20,7 @@ endif
 LOCAL_C_INCLUDES+= $(kernel_includes)
 LOCAL_ADDITIONAL_DEPENDENCIES := $(common_deps)
 
-LIB2D_ROTATION=true
+LIB2D_ROTATION=false
 
 LOCAL_C_INCLUDES += \
     $(LOCAL_PATH)/inc \

--- a/QCamera2/stack/mm-jpeg-interface/inc/mm_jpeg.h
+++ b/QCamera2/stack/mm-jpeg-interface/inc/mm_jpeg.h
@@ -426,10 +426,6 @@ typedef struct mm_jpeg_obj_t {
 
   // dummy OMX handle
   OMX_HANDLETYPE dummy_handle;
-
-  /* lib2d handle*/
-  void *static_lib2d_handle;
-
 } mm_jpeg_obj;
 
 /** mm_jpeg_pending_func_t:

--- a/QCamera2/stack/mm-jpeg-interface/inc/mm_jpeg.h
+++ b/QCamera2/stack/mm-jpeg-interface/inc/mm_jpeg.h
@@ -429,7 +429,6 @@ typedef struct mm_jpeg_obj_t {
 
   /* lib2d handle*/
   void *static_lib2d_handle;
-  uint32_t is_lib2d_enable;
 
 } mm_jpeg_obj;
 

--- a/QCamera2/stack/mm-jpeg-interface/src/mm_jpeg.c
+++ b/QCamera2/stack/mm-jpeg-interface/src/mm_jpeg.c
@@ -2400,21 +2400,6 @@ int32_t mm_jpeg_init(mm_jpeg_obj *my_obj)
   // create dummy OMX handle to avoid dlopen latency
   OMX_GetHandle(&my_obj->dummy_handle, mm_jpeg_get_comp_name(), NULL, NULL);
 
-#ifdef LIB2D_ROTATION_ENABLE
-  cam_format_t lib2d_format;
-  LOGD("Enable lib2d rotation");
-  lib2d_error lib2d_err = MM_LIB2D_SUCCESS;
-  lib2d_format =
-    mm_jpeg_get_imgfmt_from_colorfmt(MM_JPEG_COLOR_FORMAT_YCRCBLP_H2V2);
-  lib2d_err = mm_lib2d_init(MM_LIB2D_SYNC_MODE, lib2d_format,
-  lib2d_format, &my_obj->static_lib2d_handle);
-  if (lib2d_err != MM_LIB2D_SUCCESS) {
-    LOGE("lib2d init for rotation failed\n");
-    my_obj->static_lib2d_handle = NULL;
-  }
-#endif
-
-
   return rc;
 }
 
@@ -2434,14 +2419,6 @@ int32_t mm_jpeg_deinit(mm_jpeg_obj *my_obj)
 {
   int32_t rc = 0;
   uint32_t i = 0;
-
-#ifdef LIB2D_ROTATION_ENABLE
-  lib2d_error lib2d_err = MM_LIB2D_SUCCESS;
-  lib2d_err = mm_lib2d_deinit(my_obj->static_lib2d_handle);
-  if (lib2d_err != MM_LIB2D_SUCCESS) {
-    LOGE("Error in mm_lib2d_deinit \n");
-  }
-#endif
 
   /* release jobmgr thread */
   rc = mm_jpeg_jobmgr_thread_release(my_obj);
@@ -2766,6 +2743,7 @@ int32_t mm_jpeg_start_job(mm_jpeg_obj *my_obj,
   uint32_t work_buf_size;
 
   *job_id = 0;
+
   if (!job) {
     LOGE("invalid job !!!");
     return rc;
@@ -2848,10 +2826,10 @@ int32_t mm_jpeg_start_job(mm_jpeg_obj *my_obj,
 
   memset(node, 0, sizeof(mm_jpeg_job_q_node_t));
   node->enc_info.encode_job = job->encode_job;
+
 #ifdef LIB2D_ROTATION_ENABLE
   if (p_session->lib2d_rotation_flag) {
     rc = mm_jpeg_lib2d_rotation(p_session, node, job, job_id);
-    LOGH("Lib2d rotation done %d", rc);
     if (rc < 0) {
       LOGE("Lib2d rotation failed");
       return rc;
@@ -3132,23 +3110,27 @@ int32_t mm_jpeg_create_session(mm_jpeg_obj *my_obj,
       p_session->params.thumb_dim.src_dim = p_session->params.main_dim.src_dim;
       p_session->params.thumb_dim.crop = p_session->params.main_dim.crop;
     }
-
 #ifdef LIB2D_ROTATION_ENABLE
     if (p_session->params.rotation) {
-      if (my_obj->static_lib2d_handle == NULL) {
+      LOGD("Enable lib2d rotation");
+      p_session->lib2d_rotation_flag = 1;
+
+      cam_format_t lib2d_format;
+      lib2d_error lib2d_err = MM_LIB2D_SUCCESS;
+      lib2d_format =
+        mm_jpeg_get_imgfmt_from_colorfmt(p_session->params.color_format);
+      lib2d_err = mm_lib2d_init(MM_LIB2D_SYNC_MODE, lib2d_format,
+      lib2d_format, &p_session->lib2d_handle);
+      if (lib2d_err != MM_LIB2D_SUCCESS) {
         LOGE("lib2d init for rotation failed\n");
         rc = -1;
         p_session->lib2d_rotation_flag = 0;
         goto error2;
-      } else {
-        p_session->lib2d_handle = my_obj->static_lib2d_handle;
-        p_session->lib2d_rotation_flag = 1;
       }
     } else {
+      LOGD("Disable lib2d rotation");
       p_session->lib2d_rotation_flag = 0;
     }
-    LOGH("lib2d rotation flag %d", p_session->lib2d_rotation_flag);
-
 #else
     p_session->lib2d_rotation_flag = 0;
 #endif
@@ -3367,6 +3349,16 @@ int32_t mm_jpeg_destroy_session(mm_jpeg_obj *my_obj,
 
   /* abort the current session */
   mm_jpeg_session_abort(p_session);
+
+#ifdef LIB2D_ROTATION_ENABLE
+  lib2d_error lib2d_err = MM_LIB2D_SUCCESS;
+  if (p_session->lib2d_rotation_flag) {
+    lib2d_err = mm_lib2d_deinit(p_session->lib2d_handle);
+    if (lib2d_err != MM_LIB2D_SUCCESS) {
+      LOGE("Error in mm_lib2d_deinit \n");
+    }
+  }
+#endif
 
   mm_jpeg_session_destroy(p_session);
 

--- a/QCamera2/stack/mm-jpeg-interface/src/mm_jpeg.c
+++ b/QCamera2/stack/mm-jpeg-interface/src/mm_jpeg.c
@@ -32,8 +32,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <math.h>
-#include <cutils/properties.h>
-
 #define PRCTL_H <SYSTEM_HEADER_PREFIX/prctl.h>
 #include PRCTL_H
 
@@ -64,8 +62,6 @@
 #undef MM_JPEG_CONCURRENT_SESSIONS_COUNT
 #define MM_JPEG_CONCURRENT_SESSIONS_COUNT 1
 #endif
-
-
 
 OMX_ERRORTYPE mm_jpeg_ebd(OMX_HANDLETYPE hComponent,
     OMX_PTR pAppData,
@@ -2336,7 +2332,6 @@ int32_t mm_jpeg_init(mm_jpeg_obj *my_obj)
   int32_t rc = 0;
   uint32_t work_buf_size;
   unsigned int initial_workbufs_cnt = 1;
-  char  prop[PROPERTY_VALUE_MAX];
 
   /* init locks */
   pthread_mutex_init(&my_obj->job_lock, NULL);
@@ -2405,27 +2400,19 @@ int32_t mm_jpeg_init(mm_jpeg_obj *my_obj)
   // create dummy OMX handle to avoid dlopen latency
   OMX_GetHandle(&my_obj->dummy_handle, mm_jpeg_get_comp_name(), NULL, NULL);
 
-  property_get("persist.vendor.camera.lib2d.rotation", prop, "off");
-  if (!strcmp(prop, "on")) {
-    my_obj->is_lib2d_enable = 1;
-  } else {
-    my_obj->is_lib2d_enable = 0;
+#ifdef LIB2D_ROTATION_ENABLE
+  cam_format_t lib2d_format;
+  LOGD("Enable lib2d rotation");
+  lib2d_error lib2d_err = MM_LIB2D_SUCCESS;
+  lib2d_format =
+    mm_jpeg_get_imgfmt_from_colorfmt(MM_JPEG_COLOR_FORMAT_YCRCBLP_H2V2);
+  lib2d_err = mm_lib2d_init(MM_LIB2D_SYNC_MODE, lib2d_format,
+  lib2d_format, &my_obj->static_lib2d_handle);
+  if (lib2d_err != MM_LIB2D_SUCCESS) {
+    LOGE("lib2d init for rotation failed\n");
+    my_obj->static_lib2d_handle = NULL;
   }
-  LOGD("IS lib2d_Enable %d", my_obj->is_lib2d_enable);
-
-  if (my_obj->is_lib2d_enable) {
-    cam_format_t lib2d_format;
-    LOGD("Enable lib2d rotation");
-    lib2d_error lib2d_err = MM_LIB2D_SUCCESS;
-    lib2d_format =
-      mm_jpeg_get_imgfmt_from_colorfmt(MM_JPEG_COLOR_FORMAT_YCRCBLP_H2V2);
-    lib2d_err = mm_lib2d_init(MM_LIB2D_SYNC_MODE, lib2d_format,
-    lib2d_format, &my_obj->static_lib2d_handle);
-    if (lib2d_err != MM_LIB2D_SUCCESS) {
-      LOGE("lib2d init for rotation failed\n");
-      my_obj->static_lib2d_handle = NULL;
-    }
-  }
+#endif
 
 
   return rc;
@@ -2448,13 +2435,13 @@ int32_t mm_jpeg_deinit(mm_jpeg_obj *my_obj)
   int32_t rc = 0;
   uint32_t i = 0;
 
-  if (my_obj->is_lib2d_enable) {
-    lib2d_error lib2d_err = MM_LIB2D_SUCCESS;
-    lib2d_err = mm_lib2d_deinit(my_obj->static_lib2d_handle);
-    if (lib2d_err != MM_LIB2D_SUCCESS) {
-      LOGE("Error in mm_lib2d_deinit \n");
-    }
+#ifdef LIB2D_ROTATION_ENABLE
+  lib2d_error lib2d_err = MM_LIB2D_SUCCESS;
+  lib2d_err = mm_lib2d_deinit(my_obj->static_lib2d_handle);
+  if (lib2d_err != MM_LIB2D_SUCCESS) {
+    LOGE("Error in mm_lib2d_deinit \n");
   }
+#endif
 
   /* release jobmgr thread */
   rc = mm_jpeg_jobmgr_thread_release(my_obj);
@@ -2861,16 +2848,16 @@ int32_t mm_jpeg_start_job(mm_jpeg_obj *my_obj,
 
   memset(node, 0, sizeof(mm_jpeg_job_q_node_t));
   node->enc_info.encode_job = job->encode_job;
-  if (my_obj->is_lib2d_enable) {
-    if (p_session->lib2d_rotation_flag) {
-      rc = mm_jpeg_lib2d_rotation(p_session, node, job, job_id);
-      LOGH("Lib2d rotation done %d", rc);
-      if (rc < 0) {
-        LOGE("Lib2d rotation failed");
-        return rc;
-      }
+#ifdef LIB2D_ROTATION_ENABLE
+  if (p_session->lib2d_rotation_flag) {
+    rc = mm_jpeg_lib2d_rotation(p_session, node, job, job_id);
+    LOGH("Lib2d rotation done %d", rc);
+    if (rc < 0) {
+      LOGE("Lib2d rotation failed");
+      return rc;
     }
   }
+#endif
 
   if (p_session->thumb_from_main) {
     node->enc_info.encode_job.thumb_dim.src_dim =
@@ -3146,7 +3133,7 @@ int32_t mm_jpeg_create_session(mm_jpeg_obj *my_obj,
       p_session->params.thumb_dim.crop = p_session->params.main_dim.crop;
     }
 
-  if (my_obj->is_lib2d_enable) {
+#ifdef LIB2D_ROTATION_ENABLE
     if (p_session->params.rotation) {
       if (my_obj->static_lib2d_handle == NULL) {
         LOGE("lib2d init for rotation failed\n");
@@ -3161,9 +3148,10 @@ int32_t mm_jpeg_create_session(mm_jpeg_obj *my_obj,
       p_session->lib2d_rotation_flag = 0;
     }
     LOGH("lib2d rotation flag %d", p_session->lib2d_rotation_flag);
-  } else {
+
+#else
     p_session->lib2d_rotation_flag = 0;
-  }
+#endif
 
     if (p_session->lib2d_rotation_flag) {
       p_session->num_src_rot_bufs = p_session->params.num_src_bufs;

--- a/QCamera2/stack/mm-lib2d-interface/Android.mk
+++ b/QCamera2/stack/mm-lib2d-interface/Android.mk
@@ -23,7 +23,7 @@ LOCAL_C_INCLUDES += \
     $(IMGLIB_HEADER_PATH) \
     $(LOCAL_PATH)/inc \
     $(LOCAL_PATH)/../common \
-    $(LOCAL_PATH)/../mm-camera-interface/inc \
+    $(LOCAL_PATH)/../mm-camera-interface/inc
 
 LOCAL_HEADER_LIBRARIES := libutils_headers
 ifeq ($(strip $(TARGET_USES_ION)),true)
@@ -37,7 +37,7 @@ LOCAL_SRC_FILES := \
 LOCAL_MODULE           := libmmlib2d_interface
 include $(SDCLANG_COMMON_DEFS)
 LOCAL_PRELINK_MODULE   := false
-LOCAL_SHARED_LIBRARIES := libdl libcutils liblog libmmcamera_interface
+LOCAL_SHARED_LIBRARIES := libdl libcutils liblog
 ifneq ($(TARGET_KERNEL_VERSION),$(filter $(TARGET_KERNEL_VERSION),3.18 4.4 4.9))
 LOCAL_SHARED_LIBRARIES += libion
 endif

--- a/QCamera2/stack/mm-lib2d-interface/inc/mm_lib2d.h
+++ b/QCamera2/stack/mm-lib2d-interface/inc/mm_lib2d.h
@@ -32,11 +32,12 @@
 
 #include "cam_types.h"
 #ifdef QCAMERA_REDEFINE_LOG
-#ifndef CAM_MODULE
 #define CAM_MODULE CAM_NO_MODULE
-#endif
+
 // Camera dependencies
+extern "C" {
 #include "mm_camera_dbg.h"
+}
 #endif
 
 /** lib2d_error
@@ -191,7 +192,6 @@ lib2d_error mm_lib2d_deinit(void *lib2d_obj_handle);
  *   jobid - job id of this request
  *   userdata - userdata that will be pass through callback function
  *   cb - callback function that will be called on completion of this job
- *   rotation - rotation to be applied
  *
  * Return values:
  *   MM_LIB2D_SUCCESS
@@ -202,7 +202,7 @@ lib2d_error mm_lib2d_deinit(void *lib2d_obj_handle);
  **/
 lib2d_error mm_lib2d_start_job(void *lib2d_obj_handle,
     mm_lib2d_buffer* src_buffer, mm_lib2d_buffer* dst_buffer,
-    int jobid, void *userdata, lib2d_client_cb cb, uint32_t rotation);
+    int jobid, void *userdata, lib2d_client_cb cb);
 
 #endif /* MM_LIB2D_H_ */
 

--- a/QCamera2/stack/mm-lib2d-interface/src/mm_lib2d.c
+++ b/QCamera2/stack/mm-lib2d-interface/src/mm_lib2d.c
@@ -47,7 +47,6 @@
 #include "img_buffer.h"
 #include "lib2d.h"
 #include "mm_lib2d.h"
-#include "img_meta.h"
 
 /** lib2d_job_private_info
  * @jobid: Job id of this process request
@@ -143,7 +142,6 @@ int lib2d_event_handler(void* p_appdata, img_event_t *p_event)
  *   p_appdata - lib2d test object
  *   p_in_frame - pointer to input frame
  *   p_out_frame - pointer to output frame
- *   p_meta - pointer to meta data
  *
  * Return values:
  *   IMG_SUCCESS
@@ -152,7 +150,7 @@ int lib2d_event_handler(void* p_appdata, img_event_t *p_event)
  * Notes: none
  **/
 int lib2d_callback_handler(void *userdata, img_frame_t *p_in_frame,
-  img_frame_t *p_out_frame, img_meta_t *p_meta)
+  img_frame_t *p_out_frame)
 {
   lib2d_job_private_info *job_info = NULL;
 
@@ -171,7 +169,6 @@ int lib2d_callback_handler(void *userdata, img_frame_t *p_in_frame,
   free(p_in_frame->private_data);
   free(p_in_frame);
   free(p_out_frame);
-  free(p_meta);
 
   return IMG_SUCCESS;
 }
@@ -279,7 +276,6 @@ lib2d_error lib2d_fill_img_frame(img_frame_t *p_frame,
  *
  * Notes: none
  **/
-
 lib2d_error mm_lib2d_init(lib2d_mode mode, cam_format_t src_format,
   cam_format_t dst_format, void **my_obj)
 {
@@ -486,7 +482,6 @@ lib2d_error mm_lib2d_deinit(void *lib2d_obj_handle)
  *   jobid - job id of this request
  *   userdata - userdata that will be pass through callback function
  *   cb - callback function that will be called on completion of this job
- *   rotation - rotation to be applied
  *
  * Return values:
  *   MM_LIB2D_SUCCESS
@@ -497,7 +492,7 @@ lib2d_error mm_lib2d_deinit(void *lib2d_obj_handle)
  **/
 lib2d_error mm_lib2d_start_job(void *lib2d_obj_handle,
   mm_lib2d_buffer* src_buffer, mm_lib2d_buffer* dst_buffer,
-  int jobid, void *userdata, lib2d_client_cb cb, uint32_t rotation)
+  int jobid, void *userdata, lib2d_client_cb cb)
 {
   mm_lib2d_obj        *lib2d_obj  = (mm_lib2d_obj *)lib2d_obj_handle;
   int                  rc         = IMG_SUCCESS;
@@ -514,24 +509,15 @@ lib2d_error mm_lib2d_start_job(void *lib2d_obj_handle,
     return MM_LIB2D_ERR_MEMORY;
   }
 
-  img_meta_t *p_meta = malloc(sizeof(img_meta_t));
-  if (p_meta == NULL) {
-    free(p_in_frame);
-    free(p_out_frame);
-    return MM_LIB2D_ERR_MEMORY;
-  }
-
   lib2d_job_private_info *p_job_info = malloc(sizeof(lib2d_job_private_info));
   if (p_job_info == NULL) {
     free(p_in_frame);
     free(p_out_frame);
-    free(p_meta);
     return MM_LIB2D_ERR_MEMORY;
   }
 
   memset(p_in_frame,  0x0, sizeof(img_frame_t));
   memset(p_out_frame, 0x0, sizeof(img_frame_t));
-  memset(p_meta, 0x0, sizeof(img_meta_t));
   memset(p_job_info,  0x0, sizeof(lib2d_job_private_info));
   // Fill up job info private data structure that can be used in callback to
   // inform back to the client.
@@ -548,10 +534,6 @@ lib2d_error mm_lib2d_start_job(void *lib2d_obj_handle,
   lib2d_fill_img_frame(p_in_frame, src_buffer, jobid);
   lib2d_fill_img_frame(p_out_frame, dst_buffer, jobid);
 
-  p_meta->frame_id = jobid;
-  p_meta->rotation.device_rotation = (int32_t)rotation;
-  p_meta->rotation.frame_rotation = (int32_t)rotation;
-
   // call set_param to set the source, destination formats
 
   rc = IMG_COMP_Q_BUF(p_comp, p_in_frame, IMG_IN);
@@ -561,12 +543,6 @@ lib2d_error mm_lib2d_start_job(void *lib2d_obj_handle,
   }
 
   rc = IMG_COMP_Q_BUF(p_comp, p_out_frame, IMG_OUT);
-  if (rc != IMG_SUCCESS) {
-    LOGE("rc %d", rc);
-    goto ERROR;
-  }
-
-  rc = IMG_COMP_Q_META_BUF(p_comp, p_meta);
   if (rc != IMG_SUCCESS) {
     LOGE("rc %d", rc);
     goto ERROR;
@@ -600,7 +576,6 @@ lib2d_error mm_lib2d_start_job(void *lib2d_obj_handle,
 ERROR:
   free(p_in_frame);
   free(p_out_frame);
-  free(p_meta);
   free(p_job_info);
 
   return MM_LIB2D_ERR_GENERAL;

--- a/QCamera2/stack/mm-lib2d-interface/test/mm_lib2d_test.c
+++ b/QCamera2/stack/mm-lib2d-interface/test/mm_lib2d_test.c
@@ -503,7 +503,7 @@ int main(int32_t argc, const char * argv[])
       IMG_CACHE_CLEAN_INV, IMG_INTERNAL);
 
     lib2d_err = mm_lib2d_start_job(lib2d_handle, &src_buffer, &dst_buffer,
-      index, NULL, lib2d_test_client_cb, 0);
+      index, NULL, lib2d_test_client_cb);
     if (lib2d_err != MM_LIB2D_SUCCESS) {
       printf(" ] Error in mm_lib2d_start_job \n");
       goto release;


### PR DESCRIPTION
As the title says. Lets disable lib2d so we can actually build the camera HAL.
Issue:
The issue is that lib2d relays on headers not available to us as they are proprietary so it is impossible for us to build this stack.
Solution: Disable lib2d :)

Edit: as per advice of marijn lets do this and i will later make it behind a flag so ODM builds can set a flag and build the stack.