### PR TITLE
[Q/R] Make compatible with R by dropping unnecessary C++ std version and header copies

### DIFF
--- a/QCamera2/Android.mk
+++ b/QCamera2/Android.mk
@@ -7,9 +7,6 @@ include $(CLEAR_VARS)
 SDCLANG_COMMON_DEFS := $(LOCAL_PATH)/sdllvm-common-defs.mk
 SDCLANG_FLAG_DEFS := $(LOCAL_PATH)/sdllvm-flag-defs.mk
 
-LOCAL_COPY_HEADERS_TO := qcom/camera
-LOCAL_COPY_HEADERS := QCameraFormat.h
-
 ifneq ($(call is-platform-sdk-version-at-least,28),true)
 IS_QC_BOKEH_SUPPORTED := true
 else

--- a/QCamera2/Android.mk
+++ b/QCamera2/Android.mk
@@ -97,9 +97,6 @@ endif
 ifeq ($(call is-platform-sdk-version-at-least,26),true)
 USE_DISPLAY_SERVICE := true
 LOCAL_CFLAGS += -DUSE_DISPLAY_SERVICE
-LOCAL_CFLAGS += -std=c++11 -std=gnu++1y
-else
-LOCAL_CFLAGS += -std=c++11 -std=gnu++0x
 endif
 
 #Android P onwards we use vendor prefix

--- a/QCamera2/HAL3/test/Android.mk
+++ b/QCamera2/HAL3/test/Android.mk
@@ -57,6 +57,4 @@ include $(SDCLANG_COMMON_DEFS)
 
 LOCAL_CFLAGS += -Wall -Wextra -Werror
 
-LOCAL_CFLAGS += -std=c++11 -std=gnu++0x
-
 include $(BUILD_EXECUTABLE)

--- a/QCamera2/stack/mm-camera-interface/Android.mk
+++ b/QCamera2/stack/mm-camera-interface/Android.mk
@@ -36,9 +36,6 @@ ifneq (,$(filter msm8996 sdm660 msm8998 apq8098_latv $(TRINKET),$(TARGET_BOARD_P
 endif
 
 LOCAL_CFLAGS += -D_ANDROID_ -DQCAMERA_REDEFINE_LOG
-LOCAL_COPY_HEADERS_TO := mm-camera-interface
-LOCAL_COPY_HEADERS += ../common/cam_intf.h
-LOCAL_COPY_HEADERS += ../common/cam_types.h
 LOCAL_CFLAGS  += -DFDLEAK_FLAG
 LOCAL_CFLAGS  += -DMEMLEAK_FLAG
 LOCAL_LDFLAGS += -Wl,--wrap=open -Wl,--wrap=close -Wl,--wrap=socket -Wl,--wrap=pipe -Wl,--wrap=mmap -Wl,--wrap=__open_2


### PR DESCRIPTION
Build-tested on Q Mermaid, _after_ `tm out/target/product/*/obj/include/ -r` :wink: 

@haxk20 Ping!

@jerpelea Can you change the default branch on this repo to `aosp/LA.UM.8.11.r1` too?