### PR TITLE
Qcamera2: Remove libhidltransport from Android.mk

### DIFF
--- a/QCamera2/Android.mk
+++ b/QCamera2/Android.mk
@@ -180,7 +180,7 @@ LOCAL_SHARED_LIBRARIES += libdualcameraddm
 LOCAL_CFLAGS += -DENABLE_QC_BOKEH
 endif
 ifeq ($(USE_DISPLAY_SERVICE),true)
-LOCAL_SHARED_LIBRARIES += android.frameworks.displayservice@1.0 libhidlbase libhidltransport
+LOCAL_SHARED_LIBRARIES += android.frameworks.displayservice@1.0 libhidlbase
 else
 LOCAL_SHARED_LIBRARIES += libgui
 endif


### PR DESCRIPTION
In Android Q libhidltransport was deprecated and all the symbols of this library were moved to libhidlbase.
Thus lets remove this library as it serves no purpose.

Commits that made those changes upstream:
https://android.googlesource.com/platform/system/libhidl/+/8f65ba713e73b40dc58dd7a8a702a96d6c1c2181
https://android.googlesource.com/platform/system/libhidl/+/a46371d5b3ffd08808ae93ec420721345738ec65
https://android.googlesource.com/platform/system/libhwbinder/+/09a8725d56b168668a11530537c9738f4bc58a90