### PR TITLE
[8.11.r1] QCamera2: Wrap LOGE macro with braces in ADD_SET_PARAM_ENTRY_TO_BATCH

### DIFF
--- a/QCamera2/stack/common/cam_intf.h
+++ b/QCamera2/stack/common/cam_intf.h
@@ -855,8 +855,8 @@ typedef struct cam_stream_info {
     ((NULL != TABLE_PTR) ? \
     ((TABLE_PTR->data.member_variable_##META_ID[ 0 ] = DATA), \
     (TABLE_PTR->is_valid[META_ID] = 1), (0)) : \
-    ((LOGE("Unable to set metadata TABLE_PTR:%p META_ID:%d", \
-            TABLE_PTR, META_ID)), (-1))) \
+    (({LOGE("Unable to set metadata TABLE_PTR:%p META_ID:%d", \
+            TABLE_PTR, META_ID)}), (-1))) \
 
 #define ADD_SET_PARAM_ENTRY_TO_BATCH_FOR_AUX(TABLE_PTR, AUX_TABLE_PTR, META_ID) \
     ((NULL != TABLE_PTR || (NULL != AUX_TABLE_PTR)) ? \


### PR DESCRIPTION
Wrap LOGE macro with braces in ADD_SET_PARAM_ENTRY_TO_BATCH macro to
avoid new clang-12 compound punctuation token warning

QCamera2/HAL/QCamera2HWICallbacks.cpp:2158:5: error: '(' and '{' tokens
introducing statement expression appear in different macro expansion
contexts [-Werror,-Wcompound-token-split-by-macro]
    ADD_SET_PARAM_ENTRY_TO_BATCH(pMetaData,
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
QCamera2/stack/common/cam_intf.h:858:6: note: expanded from macro 'ADD_SET_PARAM_ENTRY_TO_BATCH'
    ((LOGE("Unable to set metadata TABLE_PTR:%p META_ID:%d", \
     ^
QCamera2/HAL/QCamera2HWICallbacks.cpp:2158:5: note: '{' token is here
    ADD_SET_PARAM_ENTRY_TO_BATCH(pMetaData,
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
QCamera2/stack/common/cam_intf.h:858:7: note: expanded from macro 'ADD_SET_PARAM_ENTRY_TO_BATCH'
    ((LOGE("Unable to set metadata TABLE_PTR:%p META_ID:%d", \
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
QCamera2/stack/mm-camera-interface/inc/mm_camera_dbg.h:105:28: note: expanded from macro 'LOGE'
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
QCamera2/stack/mm-camera-interface/inc/mm_camera_dbg.h:90:5: note: expanded from macro 'CLOGE'
    CLOGx(module, CAM_GLBL_DBG_ERR, fmt, ##args)
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
QCamera2/stack/mm-camera-interface/inc/mm_camera_dbg.h:66:68: note: expanded from macro 'CLOGx'
                                                                   ^

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>