### PR TITLE
[8.11.r1] QCamera2: mm-interface: Change media entity enumeration logic for k4.19

### DIFF
--- a/QCamera2/stack/mm-camera-interface/Android.mk
+++ b/QCamera2/stack/mm-camera-interface/Android.mk
@@ -57,7 +57,7 @@ endif
 
 LOCAL_CFLAGS += -Wall -Wextra -Werror
 
-ifneq (,$(filter $(strip $(SOMC_KERNEL_VERSION)),4.9 4.14))
+ifneq (,$(filter $(strip $(SOMC_KERNEL_VERSION)),4.9 4.14 4.19))
 LOCAL_CFLAGS += -DUSE_4_9_DEFS
 endif
 


### PR DESCRIPTION
Media entity enumeration logic not supported on kernel 4.19.
The group_id field was removed from the media_entity structure
back in the 4.9 kernel, so we have to use the new entity enumeration
logic on kernel 4.19 as well.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>