### PR TITLE
QCamera3Stream.cpp: Fix concatenation of string literals in the array

### DIFF
--- a/QCamera2/HAL3/QCamera3Stream.cpp
+++ b/QCamera2/HAL3/QCamera3Stream.cpp
@@ -55,7 +55,7 @@ const char* QCamera3Stream::mStreamNames[] = {
         "CAM_RAW",
         "CAM_OFFLINE_PROC",
         "CAM_PARM",
-        "CAM_ANALYSIS"
+        "CAM_ANALYSIS",
         "CAM_MAX" };
 
 /*===========================================================================


### PR DESCRIPTION
vendor/qcom/opensource/camera/QCamera2/HAL3/QCamera3Stream.cpp:59:9: error: suspicious concatenation of string literals in an array initialization; did you me
an to separate the elements with a comma? [-Werror,-Wstring-concatenation]
        "CAM_MAX" };
        ^